### PR TITLE
Fix mail fetch, subscribe matching, bounces, and outbound retries

### DIFF
--- a/gray-duck-mail/gray-duck-mail-common/EmailClientWrapper.cs
+++ b/gray-duck-mail/gray-duck-mail-common/EmailClientWrapper.cs
@@ -1,4 +1,4 @@
-﻿using GrayDuckMail.Common.Localization;
+using GrayDuckMail.Common.Localization;
 using MailKit;
 using MailKit.Net.Imap;
 using MailKit.Net.Pop3;
@@ -199,7 +199,7 @@ namespace GrayDuckMail.Common
         /// </param>
         public void Authenticate(string userName, string password, CancellationToken cancellationToken = default)
         {
-            logger.Debug(LanguageHelper.FormatValue(ResourceName.Logger_Format_AuthenticatingWith, userName, password));
+            logger.Debug(LanguageHelper.FormatValue(ResourceName.Logger_Format_AuthenticatingAs, userName));
 
             PerformClientMethod(
                 pop3Client => pop3Client.Authenticate(userName, password, cancellationToken: cancellationToken),
@@ -214,30 +214,52 @@ namespace GrayDuckMail.Common
         /// <returns> The messages. </returns>
         public IList<MimeMessage> GetMessages(CancellationToken cancellationToken = default)
         {
+            return GetIndexedMessages(cancellationToken).Select(indexedMessage => indexedMessage.Message).ToList();
+        }
+
+        /// <summary> Gets all messages with server-specific indexing metadata. </summary>
+        /// <param name="cancellationToken">
+        ///     (Optional) A token that allows processing to be cancelled.
+        /// </param>
+        /// <returns> The indexed messages. </returns>
+        public IList<IndexedMimeMessage> GetIndexedMessages(CancellationToken cancellationToken = default)
+        {
             logger.Debug(LanguageHelper.GetValue(ResourceName.Logger_GettingMessages));
 
-            return PerformClientMethod(
+            return PerformClientMethod<IList<IndexedMimeMessage>>(
             pop3Client =>
             {
                 if(pop3Client.Count > 0)
                 {
                     var messages = pop3Client.GetMessages(0, pop3Client.Count, cancellationToken: cancellationToken);
-                    return messages;
+                    return messages.Select((message, index) => IndexedMimeMessage.IndexMimeMessage(index, message)).ToList();
                 }
 
-                return Enumerable.Empty<MimeMessage>().ToList();
+                return Enumerable.Empty<IndexedMimeMessage>().ToList();
             },
             (imapClient, imapFolder) =>
             {
                 if(imapFolder.Count > 0)
                 {
-                    var messages = Enumerable.Range(0, imapFolder.Count).Select(i => imapFolder.GetMessage(i)).ToList();
-                    return messages;
+                    var summaries = imapFolder.Fetch(0, -1, MessageSummaryItems.UniqueId, cancellationToken);
+                    return summaries.Select((summary, index) =>
+                        IndexedMimeMessage.IndexMimeMessage(index, imapFolder.GetMessage(summary.UniqueId), summary.UniqueId))
+                        .ToList();
                 }
 
-                return Enumerable.Empty<MimeMessage>().ToList();
+                return Enumerable.Empty<IndexedMimeMessage>().ToList();
             }
             );
+        }
+
+        /// <summary> Marks the specified message for deletion. </summary>
+        /// <param name="indexedMessage">    The indexed message. </param>
+        /// <param name="cancellationToken">
+        ///     (Optional) A token that allows processing to be cancelled.
+        /// </param>
+        public void DeleteMessage(IndexedMimeMessage indexedMessage, CancellationToken cancellationToken = default)
+        {
+            DeleteMessage(indexedMessage.Index, indexedMessage.ImapUniqueId, cancellationToken);
         }
 
         /// <summary> Marks the specified message for deletion. </summary>
@@ -247,13 +269,33 @@ namespace GrayDuckMail.Common
         /// </param>
         public void DeleteMessage(int index, CancellationToken cancellationToken = default)
         {
+            DeleteMessage(index, imapUniqueId: null, cancellationToken: cancellationToken);
+        }
+
+        /// <summary> Marks the specified message for deletion. </summary>
+        /// <param name="index">             Zero-based index of the message. </param>
+        /// <param name="imapUniqueId">
+        ///     (Optional) The IMAP unique identifier to delete when using an IMAP client.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     (Optional) A token that allows processing to be cancelled.
+        /// </param>
+        private void DeleteMessage(int index, UniqueId? imapUniqueId, CancellationToken cancellationToken = default)
+        {
             logger.Debug(LanguageHelper.FormatValue(ResourceName.Logger_Format_DeletingMessage, index));
 
             PerformClientMethod(
             pop3Client => pop3Client.DeleteMessage(index),
             (imapClient, imapFolder) =>
             {
-                imapFolder.SetFlags(index, MessageFlags.Deleted, false, cancellationToken: cancellationToken);
+                if (imapUniqueId.HasValue)
+                {
+                    imapFolder.SetFlags(imapUniqueId.Value, MessageFlags.Deleted, false, cancellationToken: cancellationToken);
+                }
+                else
+                {
+                    imapFolder.SetFlags(index, MessageFlags.Deleted, false, cancellationToken: cancellationToken);
+                }
             }
             );
         }

--- a/gray-duck-mail/gray-duck-mail-common/EmailHelper.cs
+++ b/gray-duck-mail/gray-duck-mail-common/EmailHelper.cs
@@ -348,6 +348,11 @@ namespace GrayDuckMail.Common
         {
             logger.Debug(LanguageHelper.FormatValue(ResourceName.Logger_RelayingMessage, recipient.Name, recipient.Email));
 
+            var originator = GetMessageOriginator(message, database);
+            var posterName = string.IsNullOrWhiteSpace(originator?.Name) ? "Unknown" : originator.Name;
+            var posterEmail = string.IsNullOrWhiteSpace(originator?.Email) ? "unknown" : originator.Email;
+            var fromDisplayName = $"{posterName} via {discussionList.Name}";
+
             var relay = SendEmail(discussionList,
                 recipient,
                 LanguageHelper.FormatValue(ResourceName.Mail_Format_Subject, message.Subject.Replace(LanguageHelper.FormatValue(ResourceName.Mail_Format_SubjectReplace, discussionList.Name), ""), discussionList.Name),
@@ -374,6 +379,10 @@ namespace GrayDuckMail.Common
 
                             bodyNode = html.DocumentNode;
                         }
+
+                        var originatorHeader = html.CreateElement("p");
+                        originatorHeader.InnerHtml = LanguageHelper.FormatValue(ResourceName.Mail_Format_HTMLRelayOriginatorMessage, posterName, posterEmail);
+                        bodyNode.PrependChild(originatorHeader);
 
                         var techHeader = html.CreateElement("mark");
                         if (UsingUnsubscribeUri)
@@ -419,7 +428,8 @@ namespace GrayDuckMail.Common
                             techHeader = LanguageHelper.FormatValue(ResourceName.Mail_Format_TextUnsubscribeEmailMessage, discussionList.Name, EmailAliasHelper.GetUnsubscribeAlias(discussionList));
                         }
                         var cleanedText = message.BodyText.Replace(techHeader, "");
-                        var modifiedText = string.Format("{0}{1}{2}", cleanedText, Environment.NewLine, techHeader);
+                        var originatorHeader = LanguageHelper.FormatValue(ResourceName.Mail_Format_TextRelayOriginatorMessage, posterName, posterEmail);
+                        var modifiedText = string.Format("{0}{1}{2}{1}{3}", originatorHeader, Environment.NewLine, cleanedText, techHeader);
 
                         return new TextPart(TextFormat.Text)
                         {
@@ -432,7 +442,8 @@ namespace GrayDuckMail.Common
                     throw formatException;
                 },
                 client,
-                stoppingToken
+                stoppingToken,
+                fromDisplayName
                 );
 
             var relayIdentifier = new RelayIdentifier()
@@ -602,13 +613,14 @@ namespace GrayDuckMail.Common
         /// <param name="bodyGenerator">     The <see cref="MimeEntity">body generator</see> function. </param>
         /// <param name="client">            The SMTP client. </param>
         /// <param name="cancellationToken"> (Optional) A token that allows processing to be cancelled. </param>
+        /// <param name="fromDisplayName">   (Optional) The sender display name. Defaults to the discussion list name. </param>
         /// <returns> A MimeMessage. </returns>
-        public static MimeMessage SendEmail(DiscussionList discussionList, Contact recipient, string subject, string replyTo, Func<MimeEntity> bodyGenerator, SmtpClient client, CancellationToken cancellationToken = default)
+        public static MimeMessage SendEmail(DiscussionList discussionList, Contact recipient, string subject, string replyTo, Func<MimeEntity> bodyGenerator, SmtpClient client, CancellationToken cancellationToken = default, string fromDisplayName = null)
         {
             logger.Debug(LanguageHelper.GetValue(ResourceName.Logger_GeneratingEmail));
 
             var message = new MimeMessage();
-            message.From.Add(new MailboxAddress(discussionList.Name, discussionList.BaseEmailAddress));
+            message.From.Add(new MailboxAddress(fromDisplayName ?? discussionList.Name, discussionList.BaseEmailAddress));
             message.ReplyTo.Add(new MailboxAddress(discussionList.Name, replyTo));
             message.To.Add(new MailboxAddress(recipient.Name, recipient.Email));
             message.Subject = subject;
@@ -875,6 +887,25 @@ namespace GrayDuckMail.Common
             }
 
             return string.Empty;
+        }
+
+        /// <summary> Gets the contact who sent a relayed message. </summary>
+        /// <param name="message">  The relayed message. </param>
+        /// <param name="database"> The database. </param>
+        /// <returns> The originator contact, if one can be determined. </returns>
+        private static Contact GetMessageOriginator(Message message, SqliteDatabase database)
+        {
+            if (message?.OriginatorContact != null)
+            {
+                return message.OriginatorContact;
+            }
+
+            if (message == null || message.OriginatorContactID == 0 || database == null)
+            {
+                return null;
+            }
+
+            return database.Contacts.Find(message.OriginatorContactID);
         }
 
         #endregion

--- a/gray-duck-mail/gray-duck-mail-common/EmailHelper.cs
+++ b/gray-duck-mail/gray-duck-mail-common/EmailHelper.cs
@@ -630,6 +630,178 @@ namespace GrayDuckMail.Common
             return message;
         }
 
+        /// <summary> Details extracted from a delivery-status notification. </summary>
+        public class BounceReport
+        {
+            /// <summary> Gets or sets the failed recipient address. </summary>
+            public string Recipient { get; set; } = string.Empty;
+
+            /// <summary> Gets or sets the delivery action from the status report. </summary>
+            public string Action { get; set; } = string.Empty;
+
+            /// <summary> Gets or sets the delivery status code from the status report. </summary>
+            public string Status { get; set; } = string.Empty;
+
+            /// <summary> Gets or sets the diagnostic code from the status report. </summary>
+            public string DiagnosticCode { get; set; } = string.Empty;
+
+            /// <summary> Gets or sets the remote MTA named in the status report. </summary>
+            public string RemoteMta { get; set; } = string.Empty;
+
+            /// <summary> Gets or sets the bounce notification message identifier. </summary>
+            public string BounceMessageId { get; set; } = string.Empty;
+
+            /// <summary> Gets or sets the bounce notification sender address. </summary>
+            public string BounceFrom { get; set; } = string.Empty;
+
+            /// <summary> Gets or sets the subject of the original bounced message. </summary>
+            public string OriginalSubject { get; set; } = string.Empty;
+
+            /// <summary> Gets or sets the message identifier of the original bounced message. </summary>
+            public string OriginalMessageId { get; set; } = string.Empty;
+
+            /// <summary> Gets or sets the sender of the original bounced message. </summary>
+            public string OriginalFrom { get; set; } = string.Empty;
+
+            /// <summary> Gets or sets the human-readable explanation from the bounce notification. </summary>
+            public string Explanation { get; set; } = string.Empty;
+
+            /// <summary> Gets the raw status report lines extracted from the notification. </summary>
+            public IList<string> StatusDetails { get; } = new List<string>();
+        }
+
+        /// <summary> Extracts delivery failure details from a bounce notification. </summary>
+        /// <param name="message"> The bounce notification. </param>
+        /// <returns> The extracted bounce report. </returns>
+        public static BounceReport GetBounceReport(IndexedMimeMessage message)
+        {
+            var report = new BounceReport();
+
+            if (message?.Message == null)
+            {
+                return report;
+            }
+
+            report.BounceMessageId = message.Message.MessageId;
+            report.BounceFrom = message.Message.From?.Mailboxes.FirstOrDefault()?.Address ?? string.Empty;
+            report.Explanation = message.Message.TextBody ?? string.Empty;
+
+            var embeddedMessage = GetEmbeddedMessage(message.Message.Body);
+            if (embeddedMessage != null)
+            {
+                report.OriginalSubject = embeddedMessage.Subject;
+                report.OriginalMessageId = embeddedMessage.MessageId;
+                report.OriginalFrom = embeddedMessage.From?.Mailboxes.FirstOrDefault()?.Address ?? string.Empty;
+            }
+
+            if (!(message.Message.Body is Multipart multipartMessage))
+            {
+                return report;
+            }
+
+            foreach (var deliveryStatus in multipartMessage.OfType<MessageDeliveryStatus>())
+            {
+                foreach (var statusGroup in deliveryStatus.StatusGroups)
+                {
+                    var action = statusGroup["Action"]?.Trim() ?? string.Empty;
+                    if (string.IsNullOrWhiteSpace(action)
+                        || !BouncedEmailStatusGroupActions.Contains(action.ToLowerInvariant()))
+                    {
+                        continue;
+                    }
+
+                    report.Action = action;
+                    report.Status = statusGroup["Status"]?.Trim() ?? string.Empty;
+                    report.DiagnosticCode = statusGroup["Diagnostic-Code"]?.Trim() ?? string.Empty;
+                    report.RemoteMta = statusGroup["Remote-MTA"]?.Trim() ?? string.Empty;
+
+                    var recipient = statusGroup["Original-Recipient"]
+                        ?? statusGroup["Failed-Recipient"]
+                        ?? statusGroup["Final-Recipient"];
+
+                    if (recipient != null)
+                    {
+                        var addressParts = recipient.Split(';');
+                        report.Recipient = (addressParts.Length > 1 ? addressParts[1] : addressParts[0]).Trim().ToLowerInvariant();
+                    }
+
+                    foreach (var group in statusGroup)
+                    {
+                        report.StatusDetails.Add(string.Format("{0}: {1}", group.Field, group.Value));
+                    }
+
+                    return report;
+                }
+            }
+
+            return report;
+        }
+
+        /// <summary>
+        /// Logs a bounce notification because these messages are not forwarded to the list owner.
+        /// </summary>
+        /// <param name="log">            The logger. </param>
+        /// <param name="discussionList"> The discussion list. </param>
+        /// <param name="report">         The bounce report. </param>
+        /// <param name="subscription">   The matched subscription, if any. </param>
+        public static void LogBounceReport(Logger log, DiscussionList discussionList, BounceReport report, ContactSubscription subscription)
+        {
+            log.Info(LanguageHelper.GetValue(ResourceName.Logger_BouncedEmailNotForwardedToOwner));
+            log.Info(LanguageHelper.FormatValue(
+                ResourceName.Logger_Format_BouncedEmailReport,
+                discussionList.Name,
+                string.IsNullOrWhiteSpace(report.Recipient) ? "UNKNOWN" : report.Recipient,
+                string.IsNullOrWhiteSpace(report.Action) ? "UNKNOWN" : report.Action,
+                string.IsNullOrWhiteSpace(report.Status) ? "UNKNOWN" : report.Status,
+                string.IsNullOrWhiteSpace(report.DiagnosticCode) ? "UNKNOWN" : report.DiagnosticCode,
+                string.IsNullOrWhiteSpace(report.RemoteMta) ? "UNKNOWN" : report.RemoteMta,
+                string.IsNullOrWhiteSpace(report.BounceMessageId) ? "UNKNOWN" : report.BounceMessageId,
+                string.IsNullOrWhiteSpace(report.OriginalSubject) ? "UNKNOWN" : report.OriginalSubject,
+                string.IsNullOrWhiteSpace(report.OriginalMessageId) ? "UNKNOWN" : report.OriginalMessageId,
+                subscription?.Contact?.Name ?? "NONE",
+                subscription?.Contact?.Email ?? "NONE"));
+
+            foreach (var statusDetail in report.StatusDetails)
+            {
+                log.Info(LanguageHelper.FormatValue(ResourceName.Logger_Format_FailureStatusGroupsLine, "status", statusDetail));
+            }
+
+            if (!string.IsNullOrWhiteSpace(report.OriginalFrom))
+            {
+                log.Info(LanguageHelper.FormatValue(ResourceName.Logger_Format_BouncedOriginalMessageFrom, report.OriginalFrom));
+            }
+
+            if (!string.IsNullOrWhiteSpace(report.Explanation))
+            {
+                log.Info(LanguageHelper.FormatValue(ResourceName.Logger_Format_BouncedEmailExplanation, report.Explanation.Trim()));
+            }
+        }
+
+        /// <summary> Gets the original message embedded in a bounce notification, if present. </summary>
+        /// <param name="body"> The message body. </param>
+        /// <returns> The embedded message. </returns>
+        private static MimeMessage GetEmbeddedMessage(MimeEntity body)
+        {
+            if (body is MessagePart messagePart)
+            {
+                return messagePart.Message;
+            }
+
+            if (body is Multipart multipart)
+            {
+                foreach (var part in multipart)
+                {
+                    var embeddedMessage = GetEmbeddedMessage(part);
+                    if (embeddedMessage != null)
+                    {
+                        return embeddedMessage;
+                    }
+                }
+            }
+
+            return null;
+        }
+
         /// <summary>
         /// Query if a messaged is a bounced message by determining if there is an error action code per
         /// <see cref="GetBouncedMessageRecipient(IndexedMimeMessage)"/>.

--- a/gray-duck-mail/gray-duck-mail-common/EmailHelper.cs
+++ b/gray-duck-mail/gray-duck-mail-common/EmailHelper.cs
@@ -174,10 +174,33 @@ namespace GrayDuckMail.Common
         /// </param>
         public static void ConfigureUnsubscribeLink(string baseUrl, bool secure, string hashSecret)
         {
-            var builder = new UriBuilder();
-            builder.Scheme = secure ? "https" : "http";
-            builder.Host = baseUrl;
-           
+            UriBuilder builder;
+
+            if (baseUrl.Contains("://"))
+            {
+                builder = new UriBuilder(baseUrl);
+            }
+            else
+            {
+                builder = new UriBuilder
+                {
+                    Scheme = secure ? "https" : "http"
+                };
+
+                var host = baseUrl;
+                var port = secure ? 443 : 80;
+                var colonIndex = baseUrl.LastIndexOf(':');
+
+                if (colonIndex > 0 && int.TryParse(baseUrl.Substring(colonIndex + 1), out var explicitPort))
+                {
+                    host = baseUrl.Substring(0, colonIndex);
+                    port = explicitPort;
+                }
+
+                builder.Host = host;
+                builder.Port = port;
+            }
+
             unsubscribeUri = builder.Uri;
             usingUnsubscribeUri = true;
             EmailHelper.hashSecret = hashSecret;

--- a/gray-duck-mail/gray-duck-mail-common/EmailHelper.cs
+++ b/gray-duck-mail/gray-duck-mail-common/EmailHelper.cs
@@ -66,7 +66,6 @@ namespace GrayDuckMail.Common
             get
             {
                 yield return SubscriptionStatus.Subscribed;
-                yield return SubscriptionStatus.AwaitingConfirmation;
             }
         }
 
@@ -114,6 +113,56 @@ namespace GrayDuckMail.Common
                 yield return STATUS_GROUP_ACTION_FAILED;
                 yield return STATUS_GROUP_ACTION_DELAYED;
             }
+        }
+
+        /// <summary> Gets the mailbox portion of an address without a plus-tag suffix. </summary>
+        /// <param name="email"> The email address. </param>
+        /// <returns> The base mailbox address. </returns>
+        /// <remarks>
+        /// For example, <c>user+tag@example.com</c> and <c>user@example.com</c> both normalize to
+        /// <c>user@example.com</c>.
+        /// </remarks>
+        public static string GetBaseEmailAddress(string email)
+        {
+            if (string.IsNullOrWhiteSpace(email))
+            {
+                return email;
+            }
+
+            var atIndex = email.LastIndexOf('@');
+            if (atIndex <= 0)
+            {
+                return email;
+            }
+
+            var localPart = email.Substring(0, atIndex);
+            var domain = email.Substring(atIndex);
+            var plusIndex = localPart.IndexOf('+');
+            if (plusIndex > 0)
+            {
+                localPart = localPart.Substring(0, plusIndex);
+            }
+
+            return localPart + domain;
+        }
+
+        /// <summary> Determines whether two addresses refer to the same mailbox. </summary>
+        /// <param name="first">  The first address. </param>
+        /// <param name="second"> The second address. </param>
+        /// <returns> True if the addresses match exactly or share the same base mailbox. </returns>
+        public static bool EmailsMatch(string first, string second)
+        {
+            if (string.IsNullOrWhiteSpace(first) || string.IsNullOrWhiteSpace(second))
+            {
+                return false;
+            }
+
+            if (string.Equals(first, second, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return string.Equals(GetBaseEmailAddress(first), GetBaseEmailAddress(second), StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary> Gets the default HTML email template. </summary>

--- a/gray-duck-mail/gray-duck-mail-common/IndexedMimeMessage.cs
+++ b/gray-duck-mail/gray-duck-mail-common/IndexedMimeMessage.cs
@@ -1,4 +1,5 @@
-﻿using GrayDuckMail.Common.Localization;
+using GrayDuckMail.Common.Localization;
+using MailKit;
 using MimeKit;
 using NLog;
 using System;
@@ -35,6 +36,13 @@ namespace GrayDuckMail.Common
         /// <value> The message. </value>
         public MimeMessage Message { get; private set; }
 
+        /// <summary>
+        /// Gets the IMAP unique identifier for this message when fetched over IMAP. POP3 clients leave
+        /// this unset.
+        /// </summary>
+        /// <value> The IMAP unique identifier. </value>
+        public UniqueId? ImapUniqueId { get; private set; }
+
         #endregion
 
         #region Constructors
@@ -56,15 +64,19 @@ namespace GrayDuckMail.Common
         /// </summary>
         /// <param name="index">           The index. </param>
         /// <param name="originalMessage"> The original message object. </param>
+        /// <param name="imapUniqueId">
+        ///     (Optional) The IMAP unique identifier for <paramref name="originalMessage"/>.
+        /// </param>
         /// <returns> An indexed message. </returns>
-        public static IndexedMimeMessage IndexMimeMessage(int index, MimeMessage originalMessage)
+        public static IndexedMimeMessage IndexMimeMessage(int index, MimeMessage originalMessage, UniqueId? imapUniqueId = null)
         {
             logger.Trace(LanguageHelper.FormatValue(ResourceName.Logger_Format_AssigningMimeMessageIndex, index, originalMessage.MessageId));
 
             var indexedMimeMessage = new IndexedMimeMessage
             {
                 Index = index,
-                Message = originalMessage
+                Message = originalMessage,
+                ImapUniqueId = imapUniqueId
             };
 
             return indexedMimeMessage;

--- a/gray-duck-mail/gray-duck-mail-common/Localization/ResourceNames.cs
+++ b/gray-duck-mail/gray-duck-mail-common/Localization/ResourceNames.cs
@@ -73,6 +73,14 @@ namespace GrayDuckMail.Common.Localization
 				Logger_Format_AssigningContact,
 		/// <summary> Assigning index {0} to {1}. </summary>
 				Logger_Format_AssigningMimeMessageIndex,
+		/// <summary> Bounce notification is not forwarded to the list owner. Details follow. </summary>
+				Logger_BouncedEmailNotForwardedToOwner,
+		/// <summary> Bounce explanation: {0} </summary>
+				Logger_Format_BouncedEmailExplanation,
+		/// <summary> Bounce on list '{0}': recipient={1}, action={2}, status={3}, diagnostic={4}, remote-mta={5}, bounce-message-id={6}, original-subject='{7}', original-message-id={8}, matched-contact={9}, matched-email={10} </summary>
+				Logger_Format_BouncedEmailReport,
+		/// <summary> Bounced original message from: {0} </summary>
+				Logger_Format_BouncedOriginalMessageFrom,
 		/// <summary> Authenticating as {0}. </summary>
 				Logger_Format_AuthenticatingAs,
 		/// <summary> Authenticating with {0}:{1}. </summary>

--- a/gray-duck-mail/gray-duck-mail-common/Localization/ResourceNames.cs
+++ b/gray-duck-mail/gray-duck-mail-common/Localization/ResourceNames.cs
@@ -258,6 +258,10 @@ namespace GrayDuckMail.Common.Localization
 		/// <summary> - Message from {0} </summary>
 		 /// <remarks> It is important that this message mirrors Mail_Format_Subject with all characters after {0}, including the first space. </remarks>
 				Mail_Format_SubjectReplace,
+		/// <summary> From: {0} ({1}) </summary>
+				Mail_Format_TextRelayOriginatorMessage,
+		/// <summary> &lt;strong&gt;From:&lt;/strong&gt; {0} &amp;lt;{1}&amp;gt; </summary>
+				Mail_Format_HTMLRelayOriginatorMessage,
 		/// <summary> Glad to have you. To send a message to everyone on the discussion list, just send an email to <a href='mailto:{0}'>{0}</a>. When you recieve a message from someone in the group, you can simply reply to that email and everyone on the discussion list will get a copy. </summary>
 				Mail_Format_SubscriptionConfirmationBody,
 		/// <summary> You've been subscribed to the '{0}' Email Discussion List </summary>

--- a/gray-duck-mail/gray-duck-mail-common/Localization/Resources.Designer.cs
+++ b/gray-duck-mail/gray-duck-mail-common/Localization/Resources.Designer.cs
@@ -1186,6 +1186,24 @@ namespace GrayDuckMail.Common.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to From: {0} ({1}).
+        /// </summary>
+        internal static string Mail_Format_TextRelayOriginatorMessage {
+            get {
+                return ResourceManager.GetString("Mail_Format_TextRelayOriginatorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;strong&gt;From:&lt;/strong&gt; {0} &amp;lt;{1}&amp;gt;.
+        /// </summary>
+        internal static string Mail_Format_HTMLRelayOriginatorMessage {
+            get {
+                return ResourceManager.GetString("Mail_Format_HTMLRelayOriginatorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Glad to have you. To send a message to everyone on the discussion list, just send an email to &lt;a href=&apos;mailto:{0}&apos;&gt;{0}&lt;/a&gt;. When you recieve a message from someone in the group, you can simply reply to that email and everyone on the discussion list will get a copy..
         /// </summary>
         internal static string Mail_Format_SubscriptionConfirmationBody {

--- a/gray-duck-mail/gray-duck-mail-common/Localization/Resources.Designer.cs
+++ b/gray-duck-mail/gray-duck-mail-common/Localization/Resources.Designer.cs
@@ -358,6 +358,42 @@ namespace GrayDuckMail.Common.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Bounce notification is not forwarded to the list owner. Details follow..
+        /// </summary>
+        internal static string Logger_BouncedEmailNotForwardedToOwner {
+            get {
+                return ResourceManager.GetString("Logger_BouncedEmailNotForwardedToOwner", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Bounce explanation: {0}.
+        /// </summary>
+        internal static string Logger_Format_BouncedEmailExplanation {
+            get {
+                return ResourceManager.GetString("Logger_Format_BouncedEmailExplanation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Bounce on list &apos;{0}&apos;: recipient={1}, action={2}, status={3}, diagnostic={4}, remote-mta={5}, bounce-message-id={6}, original-subject=&apos;{7}&apos;, original-message-id={8}, matched-contact={9}, matched-email={10}.
+        /// </summary>
+        internal static string Logger_Format_BouncedEmailReport {
+            get {
+                return ResourceManager.GetString("Logger_Format_BouncedEmailReport", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Bounced original message from: {0}.
+        /// </summary>
+        internal static string Logger_Format_BouncedOriginalMessageFrom {
+            get {
+                return ResourceManager.GetString("Logger_Format_BouncedOriginalMessageFrom", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Authenticating as {0}..
         /// </summary>
         internal static string Logger_Format_AuthenticatingAs {

--- a/gray-duck-mail/gray-duck-mail-common/Localization/Resources.de-DE.resx
+++ b/gray-duck-mail/gray-duck-mail-common/Localization/Resources.de-DE.resx
@@ -493,6 +493,12 @@
     <value> - Nachricht von {0}</value>
     <comment>It is important that this message mirrors Mail_Format_Subject with all characters after {0}, including the first space.</comment>
   </data>
+  <data name="Mail_Format_TextRelayOriginatorMessage" xml:space="preserve">
+    <value>From: {0} ({1})</value>
+  </data>
+  <data name="Mail_Format_HTMLRelayOriginatorMessage" xml:space="preserve">
+    <value>&lt;strong&gt;From:&lt;/strong&gt; {0} &amp;lt;{1}&amp;gt;</value>
+  </data>
   <data name="Mail_Format_SubscriptionConfirmationBody" xml:space="preserve">
     <value>Schön, dass Sie da sind. Um eine Nachricht an alle Mitglieder der Diskussionsliste zu senden, senden Sie einfach eine E-Mail an &lt;a href='mailto:{0}'&gt;{0}&lt;/a&gt;. Wenn Sie eine Nachricht von jemandem aus der Gruppe erhalten, können Sie einfach auf diese E-Mail antworten, und alle Mitglieder der Diskussionsliste erhalten eine Kopie.</value>
   </data>

--- a/gray-duck-mail/gray-duck-mail-common/Localization/Resources.de-DE.resx
+++ b/gray-duck-mail/gray-duck-mail-common/Localization/Resources.de-DE.resx
@@ -216,6 +216,18 @@
   <data name="Logger_Format_AssigningMimeMessageIndex" xml:space="preserve">
     <value>Zuweisung des Index {0} an {1}.</value>
   </data>
+  <data name="Logger_BouncedEmailNotForwardedToOwner" xml:space="preserve">
+    <value>Bounce notification is not forwarded to the list owner. Details follow.</value>
+  </data>
+  <data name="Logger_Format_BouncedEmailExplanation" xml:space="preserve">
+    <value>Bounce explanation: {0}</value>
+  </data>
+  <data name="Logger_Format_BouncedEmailReport" xml:space="preserve">
+    <value>Bounce on list '{0}': recipient={1}, action={2}, status={3}, diagnostic={4}, remote-mta={5}, bounce-message-id={6}, original-subject='{7}', original-message-id={8}, matched-contact={9}, matched-email={10}</value>
+  </data>
+  <data name="Logger_Format_BouncedOriginalMessageFrom" xml:space="preserve">
+    <value>Bounced original message from: {0}</value>
+  </data>
   <data name="Logger_Format_AuthenticatingAs" xml:space="preserve">
     <value>Authentifizierung als {0}.</value>
   </data>

--- a/gray-duck-mail/gray-duck-mail-common/Localization/Resources.es-ES.resx
+++ b/gray-duck-mail/gray-duck-mail-common/Localization/Resources.es-ES.resx
@@ -490,6 +490,12 @@
     <value>- Mensaje de {0}</value>
     <comment>It is important that this message mirrors Mail_Format_Subject with all characters after {0}, including the first space.</comment>
   </data>
+  <data name="Mail_Format_TextRelayOriginatorMessage" xml:space="preserve">
+    <value>From: {0} ({1})</value>
+  </data>
+  <data name="Mail_Format_HTMLRelayOriginatorMessage" xml:space="preserve">
+    <value>&lt;strong&gt;From:&lt;/strong&gt; {0} &amp;lt;{1}&amp;gt;</value>
+  </data>
   <data name="Mail_Format_SubscriptionConfirmationBody" xml:space="preserve">
     <value>Afortunado de tenerte. Para enviar un mensaje a todos los que están en la lista de discusión, simplemente envíe un correo electrónico a &lt;a href='mailto:{0}'&gt;{0}&lt;/a&gt;. Cuando recibe un mensaje de alguien en el grupo, simplemente puede responder a ese correo electrónico y todos en la lista de discusión recibirán una copia.</value>
   </data>

--- a/gray-duck-mail/gray-duck-mail-common/Localization/Resources.es-ES.resx
+++ b/gray-duck-mail/gray-duck-mail-common/Localization/Resources.es-ES.resx
@@ -213,6 +213,18 @@
   <data name="Logger_Format_AssigningMimeMessageIndex" xml:space="preserve">
     <value>Asignando índice {0} a {1}.</value>
   </data>
+  <data name="Logger_BouncedEmailNotForwardedToOwner" xml:space="preserve">
+    <value>Bounce notification is not forwarded to the list owner. Details follow.</value>
+  </data>
+  <data name="Logger_Format_BouncedEmailExplanation" xml:space="preserve">
+    <value>Bounce explanation: {0}</value>
+  </data>
+  <data name="Logger_Format_BouncedEmailReport" xml:space="preserve">
+    <value>Bounce on list '{0}': recipient={1}, action={2}, status={3}, diagnostic={4}, remote-mta={5}, bounce-message-id={6}, original-subject='{7}', original-message-id={8}, matched-contact={9}, matched-email={10}</value>
+  </data>
+  <data name="Logger_Format_BouncedOriginalMessageFrom" xml:space="preserve">
+    <value>Bounced original message from: {0}</value>
+  </data>
   <data name="Logger_Format_AuthenticatingAs" xml:space="preserve">
     <value>Autenticándose como {0}.</value>
   </data>

--- a/gray-duck-mail/gray-duck-mail-common/Localization/Resources.ja-JP.resx
+++ b/gray-duck-mail/gray-duck-mail-common/Localization/Resources.ja-JP.resx
@@ -490,6 +490,12 @@
     <value>- {0} からのメッセージ</value>
     <comment>It is important that this message mirrors Mail_Format_Subject with all characters after {0}, including the first space.</comment>
   </data>
+  <data name="Mail_Format_TextRelayOriginatorMessage" xml:space="preserve">
+    <value>From: {0} ({1})</value>
+  </data>
+  <data name="Mail_Format_HTMLRelayOriginatorMessage" xml:space="preserve">
+    <value>&lt;strong&gt;From:&lt;/strong&gt; {0} &amp;lt;{1}&amp;gt;</value>
+  </data>
   <data name="Mail_Format_SubscriptionConfirmationBody" xml:space="preserve">
     <value>よろしくお願いします。ディスカッション リストの全員にメッセージを送信するには、&lt;a href='mailto:{0}'&gt;{0}&lt;/a&gt; にメールを送信します。グループの誰かからメッセージを受け取ったら、そのメールに返信するだけで、ディスカッション リストの全員がコピーを受け取ります。</value>
   </data>

--- a/gray-duck-mail/gray-duck-mail-common/Localization/Resources.ja-JP.resx
+++ b/gray-duck-mail/gray-duck-mail-common/Localization/Resources.ja-JP.resx
@@ -213,6 +213,18 @@
   <data name="Logger_Format_AssigningMimeMessageIndex" xml:space="preserve">
     <value>インデックス {0} を {1} に割り当てています。</value>
   </data>
+  <data name="Logger_BouncedEmailNotForwardedToOwner" xml:space="preserve">
+    <value>Bounce notification is not forwarded to the list owner. Details follow.</value>
+  </data>
+  <data name="Logger_Format_BouncedEmailExplanation" xml:space="preserve">
+    <value>Bounce explanation: {0}</value>
+  </data>
+  <data name="Logger_Format_BouncedEmailReport" xml:space="preserve">
+    <value>Bounce on list '{0}': recipient={1}, action={2}, status={3}, diagnostic={4}, remote-mta={5}, bounce-message-id={6}, original-subject='{7}', original-message-id={8}, matched-contact={9}, matched-email={10}</value>
+  </data>
+  <data name="Logger_Format_BouncedOriginalMessageFrom" xml:space="preserve">
+    <value>Bounced original message from: {0}</value>
+  </data>
   <data name="Logger_Format_AuthenticatingAs" xml:space="preserve">
     <value>{0} として認証しています。</value>
   </data>

--- a/gray-duck-mail/gray-duck-mail-common/Localization/Resources.resx
+++ b/gray-duck-mail/gray-duck-mail-common/Localization/Resources.resx
@@ -493,6 +493,12 @@
     <value> - Message from {0}</value>
     <comment>It is important that this message mirrors Mail_Format_Subject with all characters after {0}, including the first space.</comment>
   </data>
+  <data name="Mail_Format_TextRelayOriginatorMessage" xml:space="preserve">
+    <value>From: {0} ({1})</value>
+  </data>
+  <data name="Mail_Format_HTMLRelayOriginatorMessage" xml:space="preserve">
+    <value>&lt;strong&gt;From:&lt;/strong&gt; {0} &amp;lt;{1}&amp;gt;</value>
+  </data>
   <data name="Mail_Format_SubscriptionConfirmationBody" xml:space="preserve">
     <value>Glad to have you. To send a message to everyone on the discussion list, just send an email to &lt;a href='mailto:{0}'&gt;{0}&lt;/a&gt;. When you recieve a message from someone in the group, you can simply reply to that email and everyone on the discussion list will get a copy.</value>
   </data>

--- a/gray-duck-mail/gray-duck-mail-common/Localization/Resources.resx
+++ b/gray-duck-mail/gray-duck-mail-common/Localization/Resources.resx
@@ -216,6 +216,18 @@
   <data name="Logger_Format_AssigningMimeMessageIndex" xml:space="preserve">
     <value>Assigning index {0} to {1}.</value>
   </data>
+  <data name="Logger_BouncedEmailNotForwardedToOwner" xml:space="preserve">
+    <value>Bounce notification is not forwarded to the list owner. Details follow.</value>
+  </data>
+  <data name="Logger_Format_BouncedEmailExplanation" xml:space="preserve">
+    <value>Bounce explanation: {0}</value>
+  </data>
+  <data name="Logger_Format_BouncedEmailReport" xml:space="preserve">
+    <value>Bounce on list '{0}': recipient={1}, action={2}, status={3}, diagnostic={4}, remote-mta={5}, bounce-message-id={6}, original-subject='{7}', original-message-id={8}, matched-contact={9}, matched-email={10}</value>
+  </data>
+  <data name="Logger_Format_BouncedOriginalMessageFrom" xml:space="preserve">
+    <value>Bounced original message from: {0}</value>
+  </data>
   <data name="Logger_Format_AuthenticatingAs" xml:space="preserve">
     <value>Authenticating as {0}.</value>
   </data>

--- a/gray-duck-mail/gray-duck-mail-web/Worker/EmailFetcher.cs
+++ b/gray-duck-mail/gray-duck-mail-web/Worker/EmailFetcher.cs
@@ -321,11 +321,13 @@ namespace GrayDuckMail.Web.Worker
         private static void ProcessBounces(DiscussionList discussionList, SqliteDatabase database, EmailClientWrapper client, IndexedMimeMessage bounce)
         {
             var bouncedFrom = bounce.Message.Sender ?? bounce.Message.From.Mailboxes.SingleOrDefault();
-            var bouncedOriginallyTo = EmailHelper.GetBouncedMessageRecipient(bounce);
-            var subscription = database.DiscussionLists.Where(_discussionList => _discussionList.ID == discussionList.ID)
-                .SelectMany(_discussionList => _discussionList.Subscriptions)
-                .Where(subscription => subscription.Contact.Email == bouncedFrom.Address || subscription.Contact.Email == bouncedOriginallyTo)
-                .SingleOrDefault();
+            var bounceReport = EmailHelper.GetBounceReport(bounce);
+            var bouncedOriginallyTo = string.IsNullOrWhiteSpace(bounceReport.Recipient)
+                ? EmailHelper.GetBouncedMessageRecipient(bounce)
+                : bounceReport.Recipient;
+            var subscription = FindSubscriptionByBounce(database, discussionList, bouncedOriginallyTo, bouncedFrom?.Address);
+
+            EmailHelper.LogBounceReport(logger, discussionList, bounceReport, subscription);
 
             if (subscription != null)
             {
@@ -541,6 +543,57 @@ namespace GrayDuckMail.Web.Worker
 
             return ResolveMatch(subscriptions.Where(subscription =>
                 EmailHelper.EmailsMatch(subscription.Contact.Email, senderEmail)));
+        }
+
+        /// <summary> Finds the subscription that matches a delivery failure notification. </summary>
+        /// <param name="database">              The database. </param>
+        /// <param name="discussionList">        The discussion list. </param>
+        /// <param name="bouncedRecipient">      The recipient named in the bounce report. </param>
+        /// <param name="bouncedSenderAddress">  The sender named in the bounce report. </param>
+        /// <returns> The subscription, if one can be determined unambiguously. </returns>
+        private static ContactSubscription FindSubscriptionByBounce(
+            SqliteDatabase database,
+            DiscussionList discussionList,
+            string bouncedRecipient,
+            string bouncedSenderAddress)
+        {
+            var subscriptions = database.ContactSubscriptions
+                .Where(subscription => subscription.DiscussionListID == discussionList.ID)
+                .Include(subscription => subscription.Contact)
+                .AsEnumerable()
+                .Where(subscription => subscription.Contact != null && !string.IsNullOrWhiteSpace(subscription.Contact.Email))
+                .ToList();
+
+            ContactSubscription ResolveExactMatch(string address)
+            {
+                if (string.IsNullOrWhiteSpace(address) || string.Equals(address, "UNKNOWN_ADDRESS", StringComparison.OrdinalIgnoreCase))
+                {
+                    return null;
+                }
+
+                var exactMatches = subscriptions
+                    .Where(subscription => string.Equals(subscription.Contact.Email, address, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+
+                if (exactMatches.Count == 1)
+                {
+                    return exactMatches[0];
+                }
+
+                var baseMatches = subscriptions
+                    .Where(subscription => EmailHelper.EmailsMatch(subscription.Contact.Email, address))
+                    .ToList();
+
+                return baseMatches.Count == 1 ? baseMatches[0] : null;
+            }
+
+            var recipientMatch = ResolveExactMatch(bouncedRecipient);
+            if (recipientMatch != null)
+            {
+                return recipientMatch;
+            }
+
+            return ResolveExactMatch(bouncedSenderAddress);
         }
 
         /// <summary> Determines whether a message references the given email address. </summary>

--- a/gray-duck-mail/gray-duck-mail-web/Worker/EmailFetcher.cs
+++ b/gray-duck-mail/gray-duck-mail-web/Worker/EmailFetcher.cs
@@ -74,7 +74,7 @@ namespace GrayDuckMail.Web.Worker
                                 {
                                     logger.Info(LanguageHelper.FormatValue(ResourceName.Logger_Format_ProcessingMessages, emailMessages.Count()));
 
-                                    var filteredSubscribe = FilterMessages(emailMessages, EmailAliasHelper.GetSubscribeAlias(discussionList));
+                                    var filteredSubscribe = FilterSubscribeMessages(emailMessages, discussionList, database);
                                     var filteredUnsubscribe = FilterMessages(emailMessages, EmailAliasHelper.GetUnsubscribeAlias(discussionList));
                                     var filteredRequest = FilterMessages(emailMessages, EmailAliasHelper.GetRequestAlias(discussionList));
                                     var filteredBouncedToBounceAlias = FilterMessages(emailMessages, EmailAliasHelper.GetBounceAlias(discussionList));
@@ -164,11 +164,38 @@ namespace GrayDuckMail.Web.Worker
         /// </param>
         private static void ProcessSubscriptionConfirmations(DiscussionList discussionList, SqliteDatabase database, EmailClientWrapper client, IndexedMimeMessage subscriptionConfirmation, CancellationToken cancellationToken = default)
         {
-            var from = subscriptionConfirmation.Message.Sender ?? subscriptionConfirmation.Message.From.Mailboxes.SingleOrDefault();
-            var subscription = database.DiscussionLists.Where(_discussionList => _discussionList.ID == discussionList.ID)
-                .SelectMany(_discussionList => _discussionList.Subscriptions)
-                .Where(subscription => subscription.Contact.Email == from.Address)
-                .SingleOrDefault();
+            var from = GetSenderAddress(subscriptionConfirmation.Message);
+            if (from == null)
+            {
+                logger.Error(LanguageHelper.FormatValue(ResourceName.Logger_Format_UnrecognizedOrUnauthorized, discussionList.Name));
+                logger.Debug(LanguageHelper.FormatValue(ResourceName.Logger_Format_MessageProcessed, subscriptionConfirmation.Message.MessageId, subscriptionConfirmation.Index));
+                client.DeleteMessage(subscriptionConfirmation, cancellationToken);
+                return;
+            }
+
+            var subscription = FindSubscriptionBySenderEmail(
+                database,
+                discussionList,
+                from.Address,
+                subscriptionConfirmation.Message,
+                SubscriptionStatus.Created,
+                SubscriptionStatus.AwaitingConfirmation);
+
+            if (subscription == null)
+            {
+                logger.Error(LanguageHelper.FormatValue(ResourceName.Logger_Format_UnrecognizedOrUnauthorizedFrom, from.Name, from.Address));
+                logger.Debug(LanguageHelper.FormatValue(ResourceName.Logger_Format_MessageProcessed, subscriptionConfirmation.Message.MessageId, subscriptionConfirmation.Index));
+                client.DeleteMessage(subscriptionConfirmation, cancellationToken);
+                return;
+            }
+
+            if (subscription.Status == SubscriptionStatus.Subscribed)
+            {
+                logger.Info(LanguageHelper.FormatValue(ResourceName.Logger_Format_UserAlreadySubscribed, subscription.Contact.Name, discussionList.Name));
+                logger.Debug(LanguageHelper.FormatValue(ResourceName.Logger_Format_MessageProcessed, subscriptionConfirmation.Message.MessageId, subscriptionConfirmation.Index));
+                client.DeleteMessage(subscriptionConfirmation, cancellationToken);
+                return;
+            }
 
             logger.Info(LanguageHelper.FormatValue(ResourceName.Logger_Format_ProcessingSubscriptionMessage, subscription.Contact.Name));
 
@@ -198,10 +225,23 @@ namespace GrayDuckMail.Web.Worker
         private static void ProcessUnsubscribeConfirmations(DiscussionList discussionList, SqliteDatabase database, EmailClientWrapper client, IndexedMimeMessage unsubscribeConfirmation)
         {
             var from = unsubscribeConfirmation.Message.Sender ?? unsubscribeConfirmation.Message.From.Mailboxes.SingleOrDefault();
-            var subscription = database.DiscussionLists.Where(_discussionList => _discussionList.ID == discussionList.ID)
-                .SelectMany(_discussionList => _discussionList.Subscriptions)
-                .Where(subscription => subscription.Contact.Email == from.Address)
-                .SingleOrDefault();
+            if (from == null)
+            {
+                logger.Error(LanguageHelper.FormatValue(ResourceName.Logger_Format_UnrecognizedOrUnauthorized, discussionList.Name));
+                logger.Debug(LanguageHelper.FormatValue(ResourceName.Logger_Format_MessageProcessed, unsubscribeConfirmation.Message.MessageId, unsubscribeConfirmation.Index));
+                client.DeleteMessage(unsubscribeConfirmation);
+                return;
+            }
+
+            var subscription = FindSubscriptionBySenderEmail(database, discussionList, from.Address, unsubscribeConfirmation.Message);
+
+            if (subscription == null)
+            {
+                logger.Error(LanguageHelper.FormatValue(ResourceName.Logger_Format_UnrecognizedOrUnauthorizedFrom, from.Name, from.Address));
+                logger.Debug(LanguageHelper.FormatValue(ResourceName.Logger_Format_MessageProcessed, unsubscribeConfirmation.Message.MessageId, unsubscribeConfirmation.Index));
+                client.DeleteMessage(unsubscribeConfirmation);
+                return;
+            }
 
             logger.Info(LanguageHelper.FormatValue(ResourceName.Logger_Format_UserUnsubscribing, subscription.Contact.Name, discussionList.Name));
             subscription.Status = SubscriptionStatus.Unsubscribed;
@@ -225,11 +265,7 @@ namespace GrayDuckMail.Web.Worker
         private static void ProcessRequests(DiscussionList discussionList, SqliteDatabase database, EmailClientWrapper client, IndexedMimeMessage request, CancellationToken cancellationToken = default)
         {
             var from = request.Message.Sender ?? request.Message.From.Mailboxes.SingleOrDefault();
-            var subscription = database.DiscussionLists.Where(_discussionList => _discussionList.ID == discussionList.ID)
-                .SelectMany(_discussionList => _discussionList.Subscriptions)
-                .Include(subscription => subscription.Contact)
-                .Where(subscription => subscription.Contact.Email == from.Address)
-                .SingleOrDefault();
+            var subscription = FindSubscriptionBySenderEmail(database, discussionList, from?.Address, request.Message);
 
             if (subscription == null)
             {
@@ -325,8 +361,17 @@ namespace GrayDuckMail.Web.Worker
 
             var from = discussionMessage.Message.Sender ?? discussionMessage.Message.From.Mailboxes.SingleOrDefault();
             var originatorSubscription = discussionList.Subscriptions
-                .Where(subscription => subscription.Contact.Email.Equals(from.Address, StringComparison.OrdinalIgnoreCase))
+                .Where(subscription => subscription.Contact != null
+                    && EmailHelper.EmailsMatch(subscription.Contact.Email, from?.Address))
                 .SingleOrDefault();
+
+            if (originatorSubscription != null
+                && (originatorSubscription.Status == SubscriptionStatus.AwaitingConfirmation
+                    || originatorSubscription.Status == SubscriptionStatus.Created))
+            {
+                ProcessSubscriptionConfirmations(discussionList, database, client, discussionMessage, cancellationToken);
+                return;
+            }
 
             if (originatorSubscription != null && EmailHelper.ContactAuthorizedStatuses.Contains(originatorSubscription.Status))
             {
@@ -386,6 +431,234 @@ namespace GrayDuckMail.Web.Worker
         }
 
         /// <summary>
+        /// Filter messages intended to confirm a subscription, including replies that were sent to the
+        /// list base address instead of the subscribe alias.
+        /// </summary>
+        /// <param name="messages">       The messages. </param>
+        /// <param name="discussionList"> The discussion list. </param>
+        /// <param name="database">       The database. </param>
+        /// <returns> Subscription confirmation messages. </returns>
+        private IEnumerable<IndexedMimeMessage> FilterSubscribeMessages(IEnumerable<IndexedMimeMessage> messages, DiscussionList discussionList, SqliteDatabase database)
+        {
+            var subscribeAlias = EmailAliasHelper.GetSubscribeAlias(discussionList);
+            logger.Debug(LanguageHelper.FormatValue(ResourceName.Logger_Format_FilteringMessages, subscribeAlias));
+
+            var pendingSubscriptions = database.ContactSubscriptions
+                .Where(subscription => subscription.DiscussionListID == discussionList.ID)
+                .Where(subscription => subscription.Status == SubscriptionStatus.AwaitingConfirmation || subscription.Status == SubscriptionStatus.Created)
+                .Include(subscription => subscription.Contact)
+                .AsEnumerable()
+                .Where(subscription => subscription.Contact != null && !string.IsNullOrWhiteSpace(subscription.Contact.Email))
+                .ToList();
+
+            return messages.Where(message =>
+            {
+                if (IsAddressedTo(message.Message, subscribeAlias))
+                {
+                    return true;
+                }
+
+                var from = GetSenderAddress(message.Message);
+                if (from == null)
+                {
+                    return false;
+                }
+
+                return pendingSubscriptions.Any(subscription => EmailHelper.EmailsMatch(subscription.Contact.Email, from.Address));
+            });
+        }
+
+        /// <summary> Finds a list subscription for the sender's email address. </summary>
+        /// <param name="database">           The database. </param>
+        /// <param name="discussionList">     The discussion list. </param>
+        /// <param name="senderEmail">        The sender email. </param>
+        /// <param name="message">            (Optional) The message being processed. </param>
+        /// <param name="preferredStatuses">  (Optional) Preferred subscription statuses when multiple contacts match. </param>
+        /// <returns> The subscription, if one exists. </returns>
+        private static ContactSubscription FindSubscriptionBySenderEmail(
+            SqliteDatabase database,
+            DiscussionList discussionList,
+            string senderEmail,
+            MimeMessage message = null,
+            params SubscriptionStatus[] preferredStatuses)
+        {
+            if (string.IsNullOrWhiteSpace(senderEmail))
+            {
+                return null;
+            }
+
+            var subscriptions = database.ContactSubscriptions
+                .Where(subscription => subscription.DiscussionListID == discussionList.ID)
+                .Include(subscription => subscription.Contact)
+                .AsEnumerable()
+                .Where(subscription => subscription.Contact != null && !string.IsNullOrWhiteSpace(subscription.Contact.Email))
+                .ToList();
+
+            ContactSubscription ResolveMatch(IEnumerable<ContactSubscription> matches)
+            {
+                var matchedSubscriptions = matches.ToList();
+                if (matchedSubscriptions.Count == 1)
+                {
+                    return matchedSubscriptions[0];
+                }
+
+                if (matchedSubscriptions.Count == 0)
+                {
+                    return null;
+                }
+
+                if (preferredStatuses != null && preferredStatuses.Length > 0)
+                {
+                    var preferredMatches = matchedSubscriptions
+                        .Where(subscription => preferredStatuses.Contains(subscription.Status))
+                        .ToList();
+
+                    if (preferredMatches.Count == 1)
+                    {
+                        return preferredMatches[0];
+                    }
+                }
+
+                return null;
+            }
+
+            var exactMatch = ResolveMatch(subscriptions.Where(subscription =>
+                string.Equals(subscription.Contact.Email, senderEmail, StringComparison.OrdinalIgnoreCase)));
+            if (exactMatch != null)
+            {
+                return exactMatch;
+            }
+
+            if (message != null)
+            {
+                var referencedMatch = ResolveMatch(subscriptions.Where(subscription =>
+                    MessageReferencesEmail(message, subscription.Contact.Email)));
+                if (referencedMatch != null)
+                {
+                    return referencedMatch;
+                }
+            }
+
+            return ResolveMatch(subscriptions.Where(subscription =>
+                EmailHelper.EmailsMatch(subscription.Contact.Email, senderEmail)));
+        }
+
+        /// <summary> Determines whether a message references the given email address. </summary>
+        /// <param name="message"> The message. </param>
+        /// <param name="address"> The address. </param>
+        /// <returns> True if the message references the address. </returns>
+        private static bool MessageReferencesEmail(MimeMessage message, string address)
+        {
+            if (string.IsNullOrWhiteSpace(address))
+            {
+                return false;
+            }
+
+            if (message.GetRecipients(true).Any(recipient => EmailHelper.EmailsMatch(recipient.Address, address)))
+            {
+                return true;
+            }
+
+            for (int i = 0; i < message.Headers.Count; i++)
+            {
+                if (AddressAppearsInHeaderValue(message.Headers[i].Value, address))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Determines whether a message was addressed to the given mailbox, including envelope-only
+        /// targets added by mail server alias forwarding.
+        /// </summary>
+        /// <param name="message"> The message. </param>
+        /// <param name="address"> The target address. </param>
+        /// <returns> True if the message was addressed to the target. </returns>
+        private static bool IsAddressedTo(MimeMessage message, string address)
+        {
+            if (string.IsNullOrWhiteSpace(address))
+            {
+                return false;
+            }
+
+            if (message.GetRecipients(true).Any(recipient => recipient.Address.Equals(address, StringComparison.OrdinalIgnoreCase)))
+            {
+                return true;
+            }
+
+            foreach (var headerName in new[] { "Delivered-To", "X-Original-To", "X-Envelope-To", "Envelope-To", "X-Forwarded-To", "X-Real-To" })
+            {
+                if (HeaderContainsAddress(message, headerName, address))
+                {
+                    return true;
+                }
+            }
+
+            for (int i = 0; i < message.Headers.Count; i++)
+            {
+                if (!message.Headers[i].Field.Equals("Received", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (AddressAppearsInHeaderValue(message.Headers[i].Value, address))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary> Determines whether a header contains the given email address. </summary>
+        /// <param name="message">    The message. </param>
+        /// <param name="headerName"> Name of the header. </param>
+        /// <param name="address">    The address. </param>
+        /// <returns> True if the header contains the address. </returns>
+        private static bool HeaderContainsAddress(MimeMessage message, string headerName, string address)
+        {
+            for (int i = 0; i < message.Headers.Count; i++)
+            {
+                if (!message.Headers[i].Field.Equals(headerName, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (AddressAppearsInHeaderValue(message.Headers[i].Value, address))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary> Determines whether a header value references the given email address. </summary>
+        /// <param name="headerValue"> The header value. </param>
+        /// <param name="address">     The address. </param>
+        /// <returns> True if the value references the address. </returns>
+        private static bool AddressAppearsInHeaderValue(string headerValue, string address)
+        {
+            if (string.IsNullOrWhiteSpace(headerValue) || string.IsNullOrWhiteSpace(address))
+            {
+                return false;
+            }
+
+            return headerValue.IndexOf(address, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        /// <summary> Gets the sender address from a message. </summary>
+        /// <param name="message"> The message. </param>
+        /// <returns> The sender address, if one could be determined. </returns>
+        private static MailboxAddress GetSenderAddress(MimeMessage message)
+        {
+            return message.From.Mailboxes.FirstOrDefault() ?? message.Sender;
+        }
+
+        /// <summary>
         /// Filter messages based on the <see cref="MailboxAddress"/> located in
         /// <see cref="MimeKit.MimeMessage.To">"TO" addresses</see>.
         /// </summary>
@@ -398,9 +671,8 @@ namespace GrayDuckMail.Web.Worker
         {
             logger.Debug(LanguageHelper.FormatValue(ResourceName.Logger_Format_FilteringMessages, emailToAddress));
 
-            var filteredMessages = messages.Select(message => (Message: message, Recipients: message.Message.GetRecipients(true)))
-            .Where(anon => anon.Recipients.Any(rec => rec.Address.Equals(emailToAddress, StringComparison.OrdinalIgnoreCase)))
-            .Select(anon => anon.Message);
+            var filteredMessages = messages
+            .Where(message => IsAddressedTo(message.Message, emailToAddress));
 
             return filteredMessages;
         }

--- a/gray-duck-mail/gray-duck-mail-web/Worker/EmailFetcher.cs
+++ b/gray-duck-mail/gray-duck-mail-web/Worker/EmailFetcher.cs
@@ -68,7 +68,7 @@ namespace GrayDuckMail.Web.Worker
                                 logger.Debug(LanguageHelper.FormatValue(ResourceName.Logger_Format_AuthenticatingAs, discussionList.UserName));
                                 client.Authenticate(discussionList.UserName, discussionList.Password, cancellationToken: cancellationToken);
 
-                                var emailMessages = client.GetMessages(cancellationToken).Select((emailMessage, index) => IndexedMimeMessage.IndexMimeMessage(index, emailMessage));
+                                var emailMessages = client.GetIndexedMessages(cancellationToken);
                                 
                                 if (emailMessages.Any())
                                 {
@@ -184,7 +184,7 @@ namespace GrayDuckMail.Web.Worker
             SharedMemory.AddEmail(EmailDefinition.CreateSubscriptionConfirmation(discussionList, subscription.Contact));
 
             logger.Debug(LanguageHelper.FormatValue(ResourceName.Logger_Format_MessageProcessed, subscriptionConfirmation.Message.MessageId, subscriptionConfirmation.Index));
-            client.DeleteMessage(subscriptionConfirmation.Index, cancellationToken);
+            client.DeleteMessage(subscriptionConfirmation, cancellationToken);
         }
 
         /// <summary>
@@ -209,7 +209,7 @@ namespace GrayDuckMail.Web.Worker
             SharedMemory.AddEmail(EmailDefinition.CreateUnsubscriptionConfirmation(discussionList, subscription.Contact));
 
             logger.Debug(LanguageHelper.FormatValue(ResourceName.Logger_Format_MessageProcessed, unsubscribeConfirmation.Message.MessageId, unsubscribeConfirmation.Index));
-            client.DeleteMessage(unsubscribeConfirmation.Index);
+            client.DeleteMessage(unsubscribeConfirmation);
         }
 
         /// <summary>
@@ -274,7 +274,7 @@ namespace GrayDuckMail.Web.Worker
             }
 
             logger.Debug(LanguageHelper.FormatValue(ResourceName.Logger_Format_MessageProcessed, request.Message.MessageId, request.Index));
-            client.DeleteMessage(request.Index, cancellationToken);
+            client.DeleteMessage(request, cancellationToken);
         }
 
         /// <summary> Process the bounced messages recieved from a contact. </summary>
@@ -303,7 +303,7 @@ namespace GrayDuckMail.Web.Worker
             }
 
             logger.Debug(LanguageHelper.FormatValue(ResourceName.Logger_Format_MessageProcessed, bounce.Message.MessageId, bounce.Index));
-            client.DeleteMessage(bounce.Index);
+            client.DeleteMessage(bounce);
         }
 
         /// <summary>
@@ -382,7 +382,7 @@ namespace GrayDuckMail.Web.Worker
             }
 
             logger.Debug(LanguageHelper.FormatValue(ResourceName.Logger_Format_MessageProcessed, discussionMessage.Message.MessageId, discussionMessage.Index));
-            client.DeleteMessage(discussionMessage.Index, cancellationToken);
+            client.DeleteMessage(discussionMessage, cancellationToken);
         }
 
         /// <summary>

--- a/gray-duck-mail/gray-duck-mail-web/Worker/EmailSender.cs
+++ b/gray-duck-mail/gray-duck-mail-web/Worker/EmailSender.cs
@@ -54,9 +54,11 @@ namespace GrayDuckMail.Web.Worker
             {
                 for (int i = 0; i < DockerEnvironmentVariables.RateLimitPerRoundCount; i++)
                 {
+                    EmailDefinition emailDefinition = null;
+
                     try
                     {
-                        var emailDefinition = SharedMemory.PopEmail();
+                        emailDefinition = SharedMemory.PopEmail();
 
                         if (emailDefinition != null)
                         {
@@ -116,6 +118,13 @@ namespace GrayDuckMail.Web.Worker
                     {
                         //We want to catch any potential exception so that the loop can continue in case of failure.
                         logger.Error(e);
+
+                        if (emailDefinition != null && IsTransientSmtpFailure(e))
+                        {
+                            SharedMemory.AddEmail(emailDefinition);
+                            logger.Warn("Re-queued email after transient SMTP failure ({0}).", emailDefinition.Type);
+                            break;
+                        }
                     }
                 }
 
@@ -126,6 +135,20 @@ namespace GrayDuckMail.Web.Worker
 
             logger.Info(LanguageHelper.GetValue(ResourceName.Logger_EmailSenderShutDown));
             return;
+        }
+
+        /// <summary> Determines whether an SMTP failure is transient and safe to retry later. </summary>
+        /// <param name="exception"> The exception. </param>
+        /// <returns> True if the failure is transient. </returns>
+        private static bool IsTransientSmtpFailure(Exception exception)
+        {
+            if (!(exception is SmtpCommandException smtpException))
+            {
+                return false;
+            }
+
+            var statusCode = (int)smtpException.StatusCode;
+            return statusCode >= 400 && statusCode < 500;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fix app startup when the unsubscribe URL uses host:port format
- Remove processed mail from the inbox reliably and stop logging mailbox passwords
- Match subscribe confirmations across plus-addresses and alias forwarding
- Log bounce DSN details and match bounced contacts without plus-tag ambiguity
- Re-queue outbound mail after transient SMTP failures such as rate limits
- Show the poster's name and email in relayed list messages

## Test plan
- [ ] Start the app with `WEB_EXTERNAL_URL` set to `host:port` and confirm no startup crash
- [ ] Send a subscribe reply from a plus-address and confirm the contact is subscribed
- [ ] Trigger a bounce and confirm DSN details appear in logs and the contact is marked bounced
- [ ] Confirm rate-limited SMTP sends are retried on the next round
- [ ] Post to a list and confirm relay email shows poster name/email and `Name via List Name` as sender display