### PR TITLE
Fix list editing, logging timestamps, and XML docs

### DIFF
--- a/gray-duck-mail/gray-duck-mail-common/EmailDefinition.cs
+++ b/gray-duck-mail/gray-duck-mail-common/EmailDefinition.cs
@@ -14,14 +14,24 @@ namespace GrayDuckMail.Common
         /// <value> The type. </value>
         public EmailDefinitionType Type { get; set; }
 
+        /// <summary> Gets or sets the contact being mailed. </summary>
+        /// <value> The contact. </value>
         public Contact Contact { get; set; }
 
+        /// <summary> Gets or sets the discussion list for the email. </summary>
+        /// <value> The discussion list. </value>
         public DiscussionList DiscussionList { get; set; }
 
+        /// <summary> Gets or sets the email subject. </summary>
+        /// <value> The subject. </value>
         public string Subject { get; set; }
 
+        /// <summary> Gets or sets the email body. </summary>
+        /// <value> The body. </value>
         public string Body { get; set; }
 
+        /// <summary> Gets or sets the relayed message, if any. </summary>
+        /// <value> The message. </value>
         public Message Message { get; set; }
 
         #endregion

--- a/gray-duck-mail/gray-duck-mail-common/EmailHelper.cs
+++ b/gray-duck-mail/gray-duck-mail-common/EmailHelper.cs
@@ -289,6 +289,7 @@ namespace GrayDuckMail.Common
         /// <param name="body">           The body. </param>
         /// <param name="footer">         The footer. </param>
         /// <param name="discussionList"> The discussion list. </param>
+        /// <param name="contact">        The contact receiving the email. </param>
         /// <returns> A string with a processed main email template. </returns>
         public static string FillDefaultTemplate(string heading, string subheading, string body, string footer, DiscussionList discussionList, Contact contact)
         {
@@ -371,7 +372,7 @@ namespace GrayDuckMail.Common
         /// <param name="stoppingToken">
         ///     (Optional) A token that allows processing to be cancelled.
         /// </param>
-        /// <seealso cref="SendEmail(DiscussionList, Contact, string, string, Func{MimeEntity}, SmtpClient, CancellationToken)"/>
+        /// <seealso cref="SendEmail(DiscussionList, Contact, string, string, Func{MimeEntity}, SmtpClient, CancellationToken, string)"/>
         public static void RelayEmail(DiscussionList discussionList, Contact recipient, Message message, SqliteDatabase database, SmtpClient client, CancellationToken stoppingToken = default)
         {
             logger.Debug(LanguageHelper.FormatValue(ResourceName.Logger_RelayingMessage, recipient.Name, recipient.Email));
@@ -495,7 +496,7 @@ namespace GrayDuckMail.Common
         /// <param name="cancellationToken">
         ///     (Optional) A token that allows processing to be cancelled.
         /// </param>
-        /// <seealso cref="SendEmail(DiscussionList, Contact, string, string, Func{MimeEntity}, SmtpClient, CancellationToken)"/>
+        /// <seealso cref="SendEmail(DiscussionList, Contact, string, string, Func{MimeEntity}, SmtpClient, CancellationToken, string)"/>
         public static void SendOnboardingEmail(DiscussionList discussionList, Contact recipient, SmtpClient client, CancellationToken cancellationToken = default)
         {
             logger.Info(LanguageHelper.FormatValue(ResourceName.Logger_Format_SendingOnboardingEmail, recipient.Name, recipient.Email));
@@ -570,7 +571,7 @@ namespace GrayDuckMail.Common
         /// <param name="cancellationToken">
         ///     (Optional) A token that allows processing to be cancelled.
         /// </param>
-        /// <seealso cref="SendEmail(DiscussionList, Contact, string, string, Func{MimeEntity}, SmtpClient, CancellationToken)"/>
+        /// <seealso cref="SendEmail(DiscussionList, Contact, string, string, Func{MimeEntity}, SmtpClient, CancellationToken, string)"/>
         public static void SendSubscriptionConfirmationEmail(DiscussionList discussionList, Contact recipient, SmtpClient client, CancellationToken cancellationToken = default)
         {
             logger.Info(LanguageHelper.FormatValue(ResourceName.Logger_Format_SendingSubscriptionConfirmation, recipient.Name, recipient.Email));
@@ -604,7 +605,7 @@ namespace GrayDuckMail.Common
         /// <param name="cancellationToken">
         ///     (Optional) A token that allows processing to be cancelled.
         /// </param>
-        /// <seealso cref="SendEmail(DiscussionList, Contact, string, string, Func{MimeEntity}, SmtpClient, CancellationToken)"/>
+        /// <seealso cref="SendEmail(DiscussionList, Contact, string, string, Func{MimeEntity}, SmtpClient, CancellationToken, string)"/>
         public static void SendUnsubscriptionConfirmationEmail(DiscussionList discussionList, Contact recipient, SmtpClient client, CancellationToken cancellationToken = default)
         {
             logger.Info(LanguageHelper.FormatValue(ResourceName.Logger_Format_SendingUnsubscriptionConfirmation), recipient.Name, recipient.Email);

--- a/gray-duck-mail/gray-duck-mail-common/HashHelper.cs
+++ b/gray-duck-mail/gray-duck-mail-common/HashHelper.cs
@@ -6,6 +6,7 @@ using System.Text;
 
 namespace GrayDuckMail.Common
 {
+    /// <summary> Helper methods for creating and validating secure hashes. </summary>
     public static class HashHelper
     {
         #region Members

--- a/gray-duck-mail/gray-duck-mail-common/Localization/Language.cs
+++ b/gray-duck-mail/gray-duck-mail-common/Localization/Language.cs
@@ -119,6 +119,8 @@ namespace GrayDuckMail.Common.Localization
             }
         }
 
+        /// <summary> Gets the German - Germany language. </summary>
+        /// <value> The German - Germany language. </value>
         public static Language GermanGermany
         {
             get

--- a/gray-duck-mail/gray-duck-mail-common/NLogConfiguration.cs
+++ b/gray-duck-mail/gray-duck-mail-common/NLogConfiguration.cs
@@ -31,7 +31,9 @@ namespace GrayDuckMail.Common
             configuration.AddRule(ParseLogLevel(logLevel), LogLevel.Fatal, consoleTarget);
             configuration.AddRule(ParseLogLevel(logLevel), LogLevel.Fatal, fileTarget);
 
-            consoleTarget.Layout = "[${logger}] ${message} ${exception:format=tostring}";
+            var logLayout = "${longdate} [${logger}] ${message} ${exception:format=tostring}";
+            consoleTarget.Layout = logLayout;
+            fileTarget.Layout = logLayout;
 
             consoleTarget.RowHighlightingRules.Add(
                 new ConsoleRowHighlightingRule()

--- a/gray-duck-mail/gray-duck-mail-web/Controllers/ListController.cs
+++ b/gray-duck-mail/gray-duck-mail-web/Controllers/ListController.cs
@@ -119,7 +119,10 @@ namespace GrayDuckMail.Web.Controllers
             discussionList.Description = formInput.Description;
             discussionList.BaseEmailAddress = formInput.BaseEmailAddress;
             discussionList.UserName = formInput.UserName;
-            discussionList.Password = formInput.Password;
+            if (!string.IsNullOrEmpty(formInput.Password))
+            {
+                discussionList.Password = formInput.Password;
+            }
             discussionList.IncomingMailServer = formInput.IncomingMailServer;
             discussionList.IncomingMailPort = formInput.IncomingMailPort;
             discussionList.OutgoingMailServer = formInput.OutgoingMailServer;
@@ -251,6 +254,12 @@ namespace GrayDuckMail.Web.Controllers
         [Route("List/Assign")]
         public IActionResult Assign(DiscussionListAssignForm formInput)
         {
+            if (formInput == null)
+            {
+                logger.Error(LanguageHelper.FormatValue(ResourceName.Logger_Format_FormInputMalformed, "/List/Assign"));
+                return View("Error");
+            }
+
             foreach (var assignment in formInput.Assignments)
             {
                 var subscription = this.SqliteDatabase.ContactSubscriptions

--- a/gray-duck-mail/gray-duck-mail-web/DockerEnvironmentVariables.cs
+++ b/gray-duck-mail/gray-duck-mail-web/DockerEnvironmentVariables.cs
@@ -50,7 +50,7 @@ namespace GrayDuckMail.Web
             return 20;
         });
 
-        /// <summary> The docker environment variable for <see cref=""/>. </summary>
+        /// <summary> The docker environment variable for <see cref="EmailProtocol"/>. </summary>
         private static Lazy<EmailProtocol> envEmailProtocol = new Lazy<EmailProtocol>(() =>
         {
             var emailProtocol = Environment.GetEnvironmentVariable("EMAIL_PROTOCOL");
@@ -62,7 +62,7 @@ namespace GrayDuckMail.Web
             return EmailProtocol.POP3;
         });
 
-        /// <summary> The docker environment variable for <see cref=""/>. </summary>
+        /// <summary> The docker environment variable for <see cref="IMAPFolder"/>. </summary>
         private static Lazy<string> envIMAPFolder = new Lazy<string>(() => {
             var folder = Environment.GetEnvironmentVariable("IMAP_FOLDER");
             if(!string.IsNullOrWhiteSpace(folder))
@@ -131,7 +131,7 @@ namespace GrayDuckMail.Web
             return false;
         });
 
-        /// <summary> The docker environment variable for <see cref=""/>. </summary>
+        /// <summary> The docker environment variable for <see cref="WebUseHTTPS"/>. </summary>
         private static Lazy<bool> envWebUseHTTPS = new Lazy<bool>(() =>
         {
             var webUseHTTPS = Environment.GetEnvironmentVariable("WEB_USE_HTTPS");
@@ -293,7 +293,7 @@ namespace GrayDuckMail.Web
         /// <summary>
         /// Gets a value indicating whether the an externally accessable unsubscription link is
         /// supported. If set to <see langword="true"/>, messages will replace the unsubscribe link with
-        /// a link pointing toward <see cref=""/>.
+        /// a link pointing toward <see cref="WebExternalURL"/>.
         /// </summary>
         /// <remarks> The default value is <see langword="true"/> </remarks>
         /// <value> True if an externally accessable port is exposed, false otherwise. </value>

--- a/gray-duck-mail/gray-duck-mail-web/Models/Forms/DiscussionListAssignForm.cs
+++ b/gray-duck-mail/gray-duck-mail-web/Models/Forms/DiscussionListAssignForm.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace GrayDuckMail.Web.Models.Forms
@@ -54,9 +55,16 @@ namespace GrayDuckMail.Web.Models.Forms
         {
             get
             {
-                for(int i = 0; i < ContactID.Length; i++)
+                if (this.ContactID == null)
                 {
-                    yield return (this.ContactID[i], this.Assigned.Contains(this.ContactID[i]));
+                    yield break;
+                }
+
+                var assigned = this.Assigned ?? Array.Empty<int>();
+
+                for (int i = 0; i < this.ContactID.Length; i++)
+                {
+                    yield return (this.ContactID[i], assigned.Contains(this.ContactID[i]));
                 }
             }
         }

--- a/gray-duck-mail/gray-duck-mail-web/Program.cs
+++ b/gray-duck-mail/gray-duck-mail-web/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
 using NLog;
 using System;
 using System.Collections.Generic;
@@ -45,6 +46,11 @@ namespace GrayDuckMail.Web
             Host.CreateDefaultBuilder(args)
                 .ConfigureServices((hostContext, services) =>
                 {
+                    services.Configure<ConsoleLoggerOptions>(options =>
+                    {
+                        options.TimestampFormat = "yyyy-MM-dd HH:mm:ss.fff ";
+                    });
+
                     if (!DockerEnvironmentVariables.WebOnly)
                     {
                         logger.Info(LanguageHelper.GetValue(ResourceName.Logger_RegisteringServiceWorkers));

--- a/gray-duck-mail/gray-duck-mail-web/Views/List/Edit.cshtml
+++ b/gray-duck-mail/gray-duck-mail-web/Views/List/Edit.cshtml
@@ -46,7 +46,11 @@
         </label>
         <label for="password">
             @LanguageHelper.GetValue(ResourceName.View_Common_Password)
-            <input type="password" id="password" name="password" value="@Model.DiscussionList?.Password" />
+            <input type="password" id="password" name="password" autocomplete="new-password" />
+            @if (Model.DiscussionList != null)
+            {
+                <small>Leave blank to keep the current password.</small>
+            }
             <small><i class="icofont-warning"></i> @LanguageHelper.GetValue(ResourceName.View_Common_PasswordWarning)</small>
         </label>
         <label for="incomingMailServer">


### PR DESCRIPTION
## Summary
- Keep the stored mailbox password when the List Edit password field is left blank, and stop rendering the stored password into the password input
- Treat missing Assign checkbox arrays as empty so saving with no checked contacts does not throw
- Add timestamps to NLog console/file layouts and ASP.NET Core console logging
- Fix XML documentation comments needed to quiet documentation warnings

## Cleanup notes
- Rebuilt the branch on current `master` as a single scoped commit
- Removed the rejected self-relay configuration/toggle work
- Removed the rejected Assign resend/retry onboarding work
- Removed duplicate mail-pipeline reliability/address matching/relay identity history from PR #20
- Kept generated resource entries for removed features out of the branch

## Verification
- [x] `git log --oneline origin/master..HEAD`
- [x] `rg -n "SuppressSelfRelay|suppressSelfRelay|EnableSelfRelay|ResendConfirmation|RetryOnboarding|View_List_Assign_Retry" .` returned no matches
- [x] `git diff --check origin/master..HEAD`
- [x] `docker build -f gray-duck-mail/gray-duck-mail-web/Dockerfile -t gray-duck-mail:pr19-clean gray-duck-mail`