### PR TITLE
Reload subscription state so Assign changes affect relays immediately

### DIFF
--- a/gray-duck-mail/gray-duck-mail-web/Controllers/ListController.cs
+++ b/gray-duck-mail/gray-duck-mail-web/Controllers/ListController.cs
@@ -222,7 +222,11 @@ namespace GrayDuckMail.Web.Controllers
         [Route("List/Assign/{discussionListID}")]
         public IActionResult Assign(int discussionListID)
         {
-            var discussionList = this.SqliteDatabase.DiscussionLists.Where(list => list.ID == discussionListID).FirstOrDefault();
+            var discussionList = this.SqliteDatabase.DiscussionLists
+                .Include(list => list.Subscriptions)
+                .ThenInclude(subscription => subscription.Contact)
+                .Where(list => list.ID == discussionListID)
+                .FirstOrDefault();
             var contacts = this.SqliteDatabase.Contacts.ToArray();
             var subscriptions = this.SqliteDatabase.ContactSubscriptions.Where(subscription => subscription.DiscussionListID == discussionListID)
                 .Include(subscription => subscription.Contact)
@@ -285,7 +289,8 @@ namespace GrayDuckMail.Web.Controllers
                         logger.Debug(LanguageHelper.FormatValue(ResourceName.Logger_Format_AssigningContact, assignment.ContactID, formInput.DiscussionListID));
                         subscription.Status = SubscriptionStatus.Subscribed;
                     }
-                    else if (subscription.Status == SubscriptionStatus.Denied)
+                    else if (subscription.Status == SubscriptionStatus.Denied
+                        || subscription.Status == SubscriptionStatus.Unsubscribed)
                     {
                         logger.Debug(LanguageHelper.FormatValue(ResourceName.Logger_Format_AssigningContact, assignment.ContactID, formInput.DiscussionListID));
                         subscription.Status = SubscriptionStatus.Subscribed;
@@ -293,7 +298,7 @@ namespace GrayDuckMail.Web.Controllers
                 }
                 else
                 {
-                    if (subscription != null && EmailHelper.ContactAssociatedStatuses.Contains(subscription.Status) && subscription.Contact.Activated)
+                    if (subscription != null && EmailHelper.ContactAssociatedStatuses.Contains(subscription.Status))
                     {
                         logger.Debug(LanguageHelper.FormatValue(ResourceName.Logger_Format_UnassigningContact, assignment.ContactID, formInput.DiscussionListID));
 

--- a/gray-duck-mail/gray-duck-mail-web/Models/DiscussionListAssignModel.cs
+++ b/gray-duck-mail/gray-duck-mail-web/Models/DiscussionListAssignModel.cs
@@ -1,4 +1,5 @@
-﻿using GrayDuckMail.Common.Database;
+﻿using GrayDuckMail.Common;
+using GrayDuckMail.Common.Database;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -37,6 +38,16 @@ namespace GrayDuckMail.Web.Models
                 .FirstOrDefault();
 
             return subscriptionStatus;
+        }
+
+        /// <summary>
+        /// Query if a <see cref="Contact"/> is assigned to the discussion list for mail distribution.
+        /// </summary>
+        /// <param name="contactID"> Identifier for the contact. </param>
+        /// <returns> True if assigned, false if not. </returns>
+        public bool IsAssigned(int contactID)
+        {
+            return EmailHelper.ContactAssociatedStatuses.Contains(this.GetSubscription(contactID));
         }
 
         /// <summary> Query if a <see cref="Contact"/> has an established subscription status. </summary>

--- a/gray-duck-mail/gray-duck-mail-web/Views/List/Assign.cshtml
+++ b/gray-duck-mail/gray-duck-mail-web/Views/List/Assign.cshtml
@@ -33,7 +33,7 @@
                         <input type="checkbox"
                            name="assigned"
                            id="assigned"
-                           @(EmailHelper.IsAuthorizedForMailDistribution(Model.DiscussionList, contact) ? "checked" : "" )
+                           @(Model.IsAssigned(contact.ID) ? "checked" : "" )
                            @(EmailHelper.ContactUnassignableStatuses.Contains(Model.GetSubscription(contact.ID)) ? "disabled" : "")
                            value="@contact.ID" />
                         @contact.Name

--- a/gray-duck-mail/gray-duck-mail-web/Worker/EmailFetcher.cs
+++ b/gray-duck-mail/gray-duck-mail-web/Worker/EmailFetcher.cs
@@ -66,6 +66,9 @@ namespace GrayDuckMail.Web.Worker
             {
                 try
                 {
+                    // Admin UI updates subscriptions in a separate DbContext; clear stale tracked rows.
+                    database.ChangeTracker.Clear();
+
                     var discussionLists = database.DiscussionLists.Include(list => list.Subscriptions).ThenInclude(list => list.Contact);
 
                     foreach (var discussionList in discussionLists)
@@ -413,10 +416,13 @@ namespace GrayDuckMail.Web.Worker
 
                 // Attach the message to the database for archival.
                 database.Messages.Add(message);
-                
-                var listParticipants = discussionList.Subscriptions
-                        .Where(subscription => subscription.Status == SubscriptionStatus.Subscribed)
-                        .Where(subscription => subscription.ContactID != originatorSubscription.ContactID);
+
+                var listParticipants = database.ContactSubscriptions
+                    .AsNoTracking()
+                    .Include(subscription => subscription.Contact)
+                    .Where(subscription => subscription.DiscussionListID == discussionList.ID
+                        && subscription.Status == SubscriptionStatus.Subscribed)
+                    .Where(subscription => subscription.ContactID != originatorSubscription.ContactID);
 
                 foreach (var participant in listParticipants)
                 {

--- a/gray-duck-mail/gray-duck-mail-web/Worker/EmailSender.cs
+++ b/gray-duck-mail/gray-duck-mail-web/Worker/EmailSender.cs
@@ -56,6 +56,8 @@ namespace GrayDuckMail.Web.Worker
             logger.Info(LanguageHelper.GetValue(ResourceName.Logger_BeginningSenderLoop));
             while (!cancellationToken.IsCancellationRequested)
             {
+                database.ChangeTracker.Clear();
+
                 for (int i = 0; i < DockerEnvironmentVariables.RateLimitPerRoundCount; i++)
                 {
                     EmailDefinition emailDefinition = null;
@@ -72,6 +74,19 @@ namespace GrayDuckMail.Web.Worker
                             switch (emailDefinition.Type)
                             {
                                 case EmailDefinitionType.Relay:
+                                    if (!database.ContactSubscriptions.AsNoTracking().Any(subscription =>
+                                            subscription.DiscussionListID == emailDefinition.DiscussionList.ID
+                                            && subscription.ContactID == emailDefinition.Contact.ID
+                                            && subscription.Status == SubscriptionStatus.Subscribed))
+                                    {
+                                        logger.Info(
+                                            "Skipping relay to {0} ({1}); contact is not subscribed on list {2}.",
+                                            emailDefinition.Contact.Name,
+                                            emailDefinition.Contact.Email,
+                                            emailDefinition.DiscussionList.Name);
+                                        break;
+                                    }
+
                                     using (var smtpClient = new SmtpClient())
                                     {
                                         EmailHelper.RelayEmail(emailDefinition.DiscussionList, emailDefinition.Contact, emailDefinition.Message, database, smtpClient, cancellationToken);

--- a/gray-duck-mail/gray-duck-mail-web/Worker/Onboarder.cs
+++ b/gray-duck-mail/gray-duck-mail-web/Worker/Onboarder.cs
@@ -46,6 +46,8 @@ namespace GrayDuckMail.Web.Worker
             logger.Info(LanguageHelper.GetValue(ResourceName.Logger_BeginningOnboarderLoop));
             while (!stoppingToken.IsCancellationRequested)
             {
+                database.ChangeTracker.Clear();
+
                 foreach (var discussionList in database.DiscussionLists)
                 {
                     logger.Debug(LanguageHelper.FormatValue(ResourceName.Logger_Format_ProcessingList, discussionList.Name));


### PR DESCRIPTION
## Summary
- Clear the EF change tracker in `EmailFetcher`, `EmailSender`, and `Onboarder` each loop so Assign saves are visible without restarting the container.
- Query subscribed relay recipients from the database (`AsNoTracking`) instead of a cached navigation collection.
- Skip queued relays at send time when a contact is no longer `Subscribed`.
- Fix Assign checkbox state via `Model.IsAssigned()` and allow unassign without requiring `Contact.Activated`.
- Re-enable contacts in `Unsubscribed` or `Denied` when the admin checks them again on Assign.

## Test plan
- [ ] Subscribe contacts A and B; send list mail → both receive relay
- [ ] Uncheck B on Assign → Save → send from A → B does not receive (`Skipping relay to B...` in logs)
- [ ] Re-check B → Save → send from A → B receives again
- [ ] Re-check a contact that was `Unsubscribed` via email link
- [ ] Confirm Assign checkboxes match subscription status
- [ ] No container restart required between steps