### PR TITLE
Add RFC 2369 list headers for deliverability

### DIFF
--- a/gray-duck-mail/gray-duck-mail-common/EmailHelper.cs
+++ b/gray-duck-mail/gray-duck-mail-common/EmailHelper.cs
@@ -42,6 +42,14 @@ namespace GrayDuckMail.Common
         /// <summary> The base URL to use when constructing externally accessable unsubscribe links. </summary>
         private static Uri unsubscribeUri;
 
+        /// <summary>
+        /// The external port for the admin web UI, used for <c>List-Archive</c> links when configured.
+        /// </summary>
+        private static int? adminExternalPort;
+
+        /// <summary> When true, outgoing mail includes a <c>List-Archive</c> header. </summary>
+        private static bool includeListArchive;
+
         /// <summary> The secret token used for creating a secure unsubscribe link. </summary>
         private static string hashSecret = string.Empty;
 
@@ -269,7 +277,15 @@ namespace GrayDuckMail.Common
         ///     (Optional) The external port for unsubscribe links. Defaults to 443 when
         ///     <paramref name="secure"/> is true, otherwise 80.
         /// </param>
-        public static void ConfigureUnsubscribeLink(string baseUrl, bool secure, string hashSecret, int? externalPort = null)
+        /// <param name="adminPort">
+        ///     (Optional) The external port for the admin web UI, used when
+        ///     <paramref name="includeListArchive"/> is true.
+        /// </param>
+        /// <param name="includeListArchive">
+        ///     When true, outgoing mail includes a <c>List-Archive</c> header pointing at the web
+        ///     archive. Defaults to false.
+        /// </param>
+        public static void ConfigureUnsubscribeLink(string baseUrl, bool secure, string hashSecret, int? externalPort = null, int? adminPort = null, bool includeListArchive = false)
         {
             var builder = new UriBuilder
             {
@@ -280,7 +296,165 @@ namespace GrayDuckMail.Common
 
             unsubscribeUri = builder.Uri;
             usingUnsubscribeUri = true;
+            adminExternalPort = adminPort;
+            EmailHelper.includeListArchive = includeListArchive;
             EmailHelper.hashSecret = hashSecret;
+        }
+
+        /// <summary>
+        /// Builds the RFC 2369 <c>List-Help</c> header value for outgoing list mail.
+        /// </summary>
+        /// <param name="discussionList"> The discussion list. </param>
+        /// <returns> A comma-separated list of angle-bracketed help URLs. </returns>
+        public static string BuildListHelpHeaderValue(DiscussionList discussionList)
+        {
+            return string.Join(", ",
+                FormatHeaderMailto(EmailAliasHelper.GetRequestAlias(discussionList), "help"),
+                FormatHeaderMailto(EmailAliasHelper.GetOwnerAlias(discussionList)));
+        }
+
+        /// <summary>
+        /// Builds the RFC 2369 <c>List-Subscribe</c> header value for outgoing list mail.
+        /// </summary>
+        /// <param name="discussionList"> The discussion list. </param>
+        /// <returns> An angle-bracketed subscribe URL. </returns>
+        public static string BuildListSubscribeHeaderValue(DiscussionList discussionList)
+        {
+            return FormatHeaderMailto(EmailAliasHelper.GetSubscribeAlias(discussionList), "subscribe");
+        }
+
+        /// <summary>
+        /// Builds the RFC 2369 <c>List-Unsubscribe</c> header value for outgoing list mail.
+        /// </summary>
+        /// <param name="discussionList"> The discussion list. </param>
+        /// <param name="recipient">    The recipient. </param>
+        /// <returns> A comma-separated list of angle-bracketed unsubscribe URLs. </returns>
+        public static string BuildListUnsubscribeHeaderValue(DiscussionList discussionList, Contact recipient)
+        {
+            var urls = new List<string>();
+
+            var webUnsubscribeUri = GetWebUnsubscribeUri(discussionList, recipient);
+            if (webUnsubscribeUri != null)
+            {
+                urls.Add(FormatHeaderUrl(webUnsubscribeUri));
+            }
+
+            urls.Add(FormatHeaderMailto(EmailAliasHelper.GetUnsubscribeAlias(discussionList), "unsubscribe"));
+
+            return string.Join(", ", urls);
+        }
+
+        /// <summary>
+        /// Builds the RFC 2369 <c>List-Post</c> header value for outgoing list mail.
+        /// </summary>
+        /// <param name="discussionList"> The discussion list. </param>
+        /// <returns> An angle-bracketed post URL. </returns>
+        public static string BuildListPostHeaderValue(DiscussionList discussionList)
+        {
+            return FormatHeaderMailto(discussionList.BaseEmailAddress);
+        }
+
+        /// <summary>
+        /// Builds the RFC 2369 <c>List-Owner</c> header value for outgoing list mail.
+        /// </summary>
+        /// <param name="discussionList"> The discussion list. </param>
+        /// <returns> An angle-bracketed owner URL. </returns>
+        public static string BuildListOwnerHeaderValue(DiscussionList discussionList)
+        {
+            return FormatHeaderMailto(EmailAliasHelper.GetOwnerAlias(discussionList));
+        }
+
+        /// <summary>
+        /// Builds the RFC 2369 <c>List-Archive</c> header value when a web archive URL is configured.
+        /// </summary>
+        /// <param name="discussionList"> The discussion list. </param>
+        /// <returns> An angle-bracketed archive URL, or null when unavailable. </returns>
+        public static string BuildListArchiveHeaderValue(DiscussionList discussionList)
+        {
+            var archiveUri = GetAdminArchiveUri(discussionList);
+            return archiveUri == null ? null : FormatHeaderUrl(archiveUri);
+        }
+
+        /// <summary> Adds RFC 2369 list command headers to an outgoing message. </summary>
+        /// <param name="message">        The message. </param>
+        /// <param name="discussionList"> The discussion list. </param>
+        /// <param name="recipient">      The recipient. </param>
+        private static void AddListCommandHeaders(MimeMessage message, DiscussionList discussionList, Contact recipient)
+        {
+            message.Headers.Add("List-Help", BuildListHelpHeaderValue(discussionList));
+            message.Headers.Add("List-Subscribe", BuildListSubscribeHeaderValue(discussionList));
+            message.Headers.Add("List-Unsubscribe", BuildListUnsubscribeHeaderValue(discussionList, recipient));
+            message.Headers.Add("List-Post", BuildListPostHeaderValue(discussionList));
+            message.Headers.Add("List-Owner", BuildListOwnerHeaderValue(discussionList));
+
+            var archiveHeader = BuildListArchiveHeaderValue(discussionList);
+            if (archiveHeader != null)
+            {
+                message.Headers.Add("List-Archive", archiveHeader);
+            }
+        }
+
+        /// <summary> Formats a URI for use in an RFC 2369 list header field. </summary>
+        /// <param name="uri"> The URI. </param>
+        /// <returns> An angle-bracketed URL. </returns>
+        private static string FormatHeaderUrl(Uri uri)
+        {
+            return $"<{uri.AbsoluteUri}>";
+        }
+
+        /// <summary> Formats a mailto URI for use in an RFC 2369 list header field. </summary>
+        /// <param name="address"> The email address. </param>
+        /// <param name="subject"> (Optional) The mailto subject parameter. </param>
+        /// <returns> An angle-bracketed mailto URL. </returns>
+        private static string FormatHeaderMailto(string address, string subject = null)
+        {
+            return subject == null
+                ? $"<mailto:{address}>"
+                : $"<mailto:{address}?subject={subject}>";
+        }
+
+        /// <summary>
+        /// Gets the per-recipient web unsubscribe URL when external unsubscribe links are enabled.
+        /// </summary>
+        /// <param name="discussionList"> The discussion list. </param>
+        /// <param name="contact">        The contact. </param>
+        /// <returns> The unsubscribe URI, or null when unavailable. </returns>
+        private static Uri GetWebUnsubscribeUri(DiscussionList discussionList, Contact contact)
+        {
+            if (!UsingUnsubscribeUri || discussionList == null || contact == null || contact.ID <= 0)
+            {
+                return null;
+            }
+
+            var customized = new UriBuilder(unsubscribeUri);
+            customized.Path = string.Format(
+                "Unsubscribe/{0}/{1}/{2}",
+                contact.ID,
+                discussionList.ID,
+                HashHelper.Hash(contact.ID, discussionList.ID, hashSecret));
+
+            return customized.Uri;
+        }
+
+        /// <summary>
+        /// Gets the web archive URL when external admin access is configured.
+        /// </summary>
+        /// <param name="discussionList"> The discussion list. </param>
+        /// <returns> The archive URI, or null when unavailable. </returns>
+        private static Uri GetAdminArchiveUri(DiscussionList discussionList)
+        {
+            if (!includeListArchive || !UsingUnsubscribeUri || !adminExternalPort.HasValue || discussionList == null)
+            {
+                return null;
+            }
+
+            var customized = new UriBuilder(unsubscribeUri)
+            {
+                Port = adminExternalPort.Value,
+                Path = string.Format("List/Archive/{0}", discussionList.ID)
+            };
+
+            return customized.Uri;
         }
 
         /// <summary> Fill the default HTML email template with values. </summary>
@@ -295,13 +469,10 @@ namespace GrayDuckMail.Common
         {
             var unsubscribe = string.Empty;
 
-            if (UsingUnsubscribeUri)
+            var webUnsubscribeUri = GetWebUnsubscribeUri(discussionList, contact);
+            if (webUnsubscribeUri != null)
             {
-                //Use an unsubscribe link that points to an externally accesible URL.
-                var customized = new UriBuilder(unsubscribeUri);
-                customized.Path = string.Format("Unsubscribe/{0}/{1}/{2}", contact.ID, discussionList.ID, HashHelper.Hash(contact.ID, discussionList.ID, hashSecret));
-
-                unsubscribe = customized.Uri.AbsoluteUri;
+                unsubscribe = webUnsubscribeUri.AbsoluteUri;
             }
             else
             {
@@ -657,6 +828,7 @@ namespace GrayDuckMail.Common
             message.To.Add(new MailboxAddress(recipient.Name, recipient.Email));
             message.Subject = subject;
             message.Headers.Insert(0, HeaderId.ReturnPath, string.Format("Bounces <{0}>", EmailAliasHelper.GetBounceAlias(discussionList)));
+            AddListCommandHeaders(message, discussionList, recipient);
 
             message.Body = bodyGenerator();
 

--- a/gray-duck-mail/gray-duck-mail-common/EmailHelper.cs
+++ b/gray-duck-mail/gray-duck-mail-common/EmailHelper.cs
@@ -50,6 +50,11 @@ namespace GrayDuckMail.Common
         /// <summary> When true, outgoing mail includes a <c>List-Archive</c> header. </summary>
         private static bool includeListArchive;
 
+        /// <summary>
+        /// The RFC 8058 <c>List-Unsubscribe-Post</c> header value signaling one-click unsubscribe.
+        /// </summary>
+        public const string ListUnsubscribePostHeaderValue = "List-Unsubscribe=One-Click";
+
         /// <summary> The secret token used for creating a secure unsubscribe link. </summary>
         private static string hashSecret = string.Empty;
 
@@ -384,6 +389,12 @@ namespace GrayDuckMail.Common
             message.Headers.Add("List-Help", BuildListHelpHeaderValue(discussionList));
             message.Headers.Add("List-Subscribe", BuildListSubscribeHeaderValue(discussionList));
             message.Headers.Add("List-Unsubscribe", BuildListUnsubscribeHeaderValue(discussionList, recipient));
+
+            if (GetWebUnsubscribeUri(discussionList, recipient) != null)
+            {
+                message.Headers.Add("List-Unsubscribe-Post", ListUnsubscribePostHeaderValue);
+            }
+
             message.Headers.Add("List-Post", BuildListPostHeaderValue(discussionList));
             message.Headers.Add("List-Owner", BuildListOwnerHeaderValue(discussionList));
 

--- a/gray-duck-mail/gray-duck-mail-web/Controllers/ExternalController.cs
+++ b/gray-duck-mail/gray-duck-mail-web/Controllers/ExternalController.cs
@@ -2,17 +2,9 @@
 using GrayDuckMail.Common.Database;
 using GrayDuckMail.Common.Localization;
 using GrayDuckMail.Web.Models;
-using GrayDuckMail.Web.Models.Forms;
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using NLog;
-using System;
-using System.IO;
-using System.IO.Compression;
 using System.Linq;
 
 namespace GrayDuckMail.Web.Controllers
@@ -44,7 +36,7 @@ namespace GrayDuckMail.Web.Controllers
         /// <summary> Gets the index or default request. </summary>
         /// <remarks>
         /// Fulfills the <c>/Unsubscribe</c> request.
-        /// 
+        ///
         /// Because this method may be accessed externally, all input must be validated and checked.
         /// </remarks>
         /// <param name="contactID">        Identifier for the contact. </param>
@@ -52,10 +44,71 @@ namespace GrayDuckMail.Web.Controllers
         /// <param name="hash">             The hash of the web server secret token, the contact ID, and the discussion list ID. </param>
         /// <returns> A response to return to the caller. </returns>
         /// <seealso cref="DockerEnvironmentVariables.WebSecret"/>
+        [HttpGet]
         [Route("/Unsubscribe/{contactID}/{discussionListID}/{hash}")]
         [ExternalAccess]
         [ViewLayout("_BlankLayout")]
         public IActionResult Unsubscribe(int contactID, int discussionListID, string hash)
+        {
+            var (discussionList, contact, success) = TryUnsubscribe(contactID, discussionListID, hash);
+
+            var model = new UnsubscribeModel()
+            {
+                DiscussionList = discussionList,
+                UserEmail = contact?.Email,
+                Successful = success
+            };
+
+            return View("Unsubscribe", model);
+        }
+
+        /// <summary>
+        /// RFC 8058 one-click unsubscribe. Mail clients POST <c>List-Unsubscribe=One-Click</c> to the
+        /// <c>List-Unsubscribe</c> HTTPS URL without user interaction.
+        /// </summary>
+        /// <param name="contactID">        Identifier for the contact. </param>
+        /// <param name="discussionListID"> Identifier for the discussion list. </param>
+        /// <param name="hash">             The hash of the web server secret token, the contact ID, and the discussion list ID. </param>
+        /// <returns> A response to return to the caller. </returns>
+        /// <seealso href="https://www.rfc-editor.org/info/rfc8058"/>
+        [HttpPost]
+        [Route("/Unsubscribe/{contactID}/{discussionListID}/{hash}")]
+        [ExternalAccess]
+        public IActionResult UnsubscribePost(int contactID, int discussionListID, string hash)
+        {
+            if (!IsOneClickUnsubscribeRequest())
+            {
+                return BadRequest();
+            }
+
+            var (_, _, success) = TryUnsubscribe(contactID, discussionListID, hash);
+
+            if (!success)
+            {
+                return BadRequest();
+            }
+
+            return Ok();
+        }
+
+        /// <summary> Query if the current request is an RFC 8058 one-click unsubscribe POST. </summary>
+        /// <returns> True if the POST body signals one-click unsubscribe. </returns>
+        private bool IsOneClickUnsubscribeRequest()
+        {
+            if (Request.HasFormContentType)
+            {
+                return Request.Form["List-Unsubscribe"].FirstOrDefault() == "One-Click";
+            }
+
+            return false;
+        }
+
+        /// <summary> Unsubscribes a contact from a discussion list when validation succeeds. </summary>
+        /// <param name="contactID">        Identifier for the contact. </param>
+        /// <param name="discussionListID"> Identifier for the discussion list. </param>
+        /// <param name="hash">             The unsubscribe link hash. </param>
+        /// <returns> The discussion list, contact, and whether unsubscription succeeded. </returns>
+        private (DiscussionList discussionList, Contact contact, bool success) TryUnsubscribe(int contactID, int discussionListID, string hash)
         {
             var success = false;
             var discussionList = this.SqliteDatabase.DiscussionLists.Where(_discussionList => _discussionList.ID == discussionListID).SingleOrDefault();
@@ -90,8 +143,8 @@ namespace GrayDuckMail.Web.Controllers
                 logger.Error(LanguageHelper.FormatValue(ResourceName.Logger_Format_InvalidUnsubscriptionSubscriptionStatus, contactID, discussionListID, subscription.Status));
             }
 
-            if (discussionList != null 
-                && contact != null 
+            if (discussionList != null
+                && contact != null
                 && subscription != null
                 && subscription.Status == SubscriptionStatus.Subscribed
                 && hashMatch)
@@ -104,14 +157,7 @@ namespace GrayDuckMail.Web.Controllers
                 success = true;
             }
 
-            var model = new UnsubscribeModel()
-            {
-                DiscussionList = discussionList,
-                UserEmail = contact?.Email,
-                Successful = success
-            };
-
-            return View("Unsubscribe", model);
+            return (discussionList, contact, success);
         }
 
         #endregion

--- a/gray-duck-mail/gray-duck-mail-web/Controllers/ListController.cs
+++ b/gray-duck-mail/gray-duck-mail-web/Controllers/ListController.cs
@@ -308,7 +308,7 @@ namespace GrayDuckMail.Web.Controllers
             return RedirectToAction("Index");
         }
 
-        /// <summary> Queues a test message in the form of an Owner Requst notification. </summary>
+        /// <summary> Queues a test message in the form of an Owner Request notification. </summary>
         /// <remarks> Fulfills the <c>/List/Test</c> request. </remarks>
         /// <param name="discussionListID"> Identifier for the discussion list. </param>
         /// <returns> A response to return to the caller. </returns>
@@ -322,13 +322,13 @@ namespace GrayDuckMail.Web.Controllers
                 .SingleOrDefault();
             var ownerContact = new Contact() { Name = "Server Test", Email = EmailAliasHelper.GetOwnerAlias(discussionList), Activated = true };
 
-            if(discussionList != null)
+            if (discussionList != null)
             {
                 logger.Info(LanguageHelper.FormatValue(ResourceName.Logger_Format_SendingTest, discussionList.Name));
 
                 SharedMemory.AddEmail(EmailDefinition.CreateOwnerNotification(discussionList, ownerContact));
-                
-                if(DockerEnvironmentVariables.WebOnly)
+
+                if (DockerEnvironmentVariables.WebOnly)
                 {
                     // If the email sending services are not running, send the email here
                     // instead to make sure it is sent.

--- a/gray-duck-mail/gray-duck-mail-web/DockerEnvironmentVariables.cs
+++ b/gray-duck-mail/gray-duck-mail-web/DockerEnvironmentVariables.cs
@@ -174,6 +174,36 @@ namespace GrayDuckMail.Web
             return null;
         });
 
+        /// <summary> The docker environment variable for <see cref="WebListArchive"/>. </summary>
+        private static Lazy<bool> envWebListArchive = new Lazy<bool>(() =>
+        {
+            var webListArchive = Environment.GetEnvironmentVariable("WEB_LIST_ARCHIVE");
+
+            if (bool.TryParse(webListArchive, out var parsedBool))
+            {
+                return parsedBool;
+            }
+            else if (int.TryParse(webListArchive, out var parsedInt))
+            {
+                return parsedInt != 0;
+            }
+
+            return false;
+        });
+
+        /// <summary> The docker environment variable for <see cref="WebAdminExternalPort"/>. </summary>
+        private static Lazy<int?> envWebAdminExternalPort = new Lazy<int?>(() =>
+        {
+            var webAdminExternalPort = Environment.GetEnvironmentVariable("WEB_ADMIN_EXTERNAL_PORT");
+
+            if (!string.IsNullOrWhiteSpace(webAdminExternalPort) && int.TryParse(webAdminExternalPort, out var value))
+            {
+                return value;
+            }
+
+            return null;
+        });
+
         /// <summary> The docker environment variable for <see cref="Language"/>. </summary>
         private static Lazy<Language> envLanguage = new Lazy<Language>(() =>
         {
@@ -330,6 +360,25 @@ namespace GrayDuckMail.Web
         public static int? WebExternalPort
         {
             get => envWebExternalPort.Value;
+        }
+
+        /// <summary>
+        /// Gets whether outgoing mail should include a <c>List-Archive</c> header.
+        /// </summary>
+        /// <remarks> Set <c>WEB_LIST_ARCHIVE</c> to <c>1</c> to enable. Defaults to off. </remarks>
+        /// <value> True when the list archive header is enabled. </value>
+        public static bool WebListArchive
+        {
+            get => envWebListArchive.Value;
+        }
+
+        /// <summary>
+        /// Gets the external port for the admin web UI, used for <c>List-Archive</c> header links.
+        /// </summary>
+        /// <value> The admin external port, if configured. </value>
+        public static int? WebAdminExternalPort
+        {
+            get => envWebAdminExternalPort.Value;
         }
 
         /// <summary> Gets the localization language. </summary>

--- a/gray-duck-mail/gray-duck-mail-web/Worker/EmailSender.cs
+++ b/gray-duck-mail/gray-duck-mail-web/Worker/EmailSender.cs
@@ -50,7 +50,9 @@ namespace GrayDuckMail.Web.Worker
                     DockerEnvironmentVariables.WebExternalURL,
                     DockerEnvironmentVariables.WebUseHTTPS,
                     DockerEnvironmentVariables.WebSecret,
-                    DockerEnvironmentVariables.WebExternalPort);
+                    DockerEnvironmentVariables.WebExternalPort,
+                    DockerEnvironmentVariables.WebAdminExternalPort,
+                    DockerEnvironmentVariables.WebListArchive);
             }
 
             logger.Info(LanguageHelper.GetValue(ResourceName.Logger_BeginningSenderLoop));


### PR DESCRIPTION
## Summary
- Add RFC 2369 list command headers (List-Help, List-Subscribe, List-Unsubscribe, List-Post, List-Owner) to all outgoing mail via `SendEmail()`
- Include optional List-Archive when `WEB_LIST_ARCHIVE=1` and `WEB_ADMIN_EXTERNAL_PORT` are set
- Use existing gray-duck-mail aliases and web unsubscribe URLs where applicable

Fixes #14

## Test plan
- [ ] Send list relay to a subscribed member; verify headers in raw message
- [ ] With `WEB_UNSUBSCRIBE=1`, confirm List-Unsubscribe includes web URL and mailto alias
- [ ] With `WEB_LIST_ARCHIVE=0`, confirm no List-Archive header
- [ ] With `WEB_LIST_ARCHIVE=1` and `WEB_ADMIN_EXTERNAL_PORT`, confirm List-Archive URL
- [ ] Run `/List/Test/{id}`; confirm mail goes to `owner-{list}` with mailto-only List-Unsubscribe